### PR TITLE
Fix javax inject dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 .idea
 nb-configuration.xml
 /bin/
+external/asm-all/dependency-reduced-pom.xml

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -24,7 +24,6 @@
         <artifactId>examples</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
     </parent>
-
     <artifactId>custom-resolver-example</artifactId>
     <name>Custom Resolver Example</name>
     <description>A use case for custom injection resolution</description>
@@ -50,11 +49,11 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/examples/operations/pom.xml
+++ b/examples/operations/pom.xml
@@ -24,7 +24,6 @@
         <artifactId>examples</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
     </parent>
-
     <artifactId>operations-example</artifactId>
     <name>Operations Example</name>
     <description>A demonstration of an HK2 Operation</description>
@@ -80,11 +79,11 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/external/jsr330/pom.xml
+++ b/external/jsr330/pom.xml
@@ -26,10 +26,8 @@
     </parent>
     <groupId>org.glassfish.hk2.external</groupId>
     <artifactId>jakarta.inject</artifactId>
-
     <name>javax.inject:${javax-inject.version} as OSGi bundle</name>
     <description>Injection API (JSR 330) version ${javax.inject.version} repackaged as OSGi bundle</description>
-
 
     <build>
         <plugins>
@@ -106,7 +104,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/guice-bridge/pom.xml
+++ b/guice-bridge/pom.xml
@@ -26,10 +26,9 @@
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>guice-bridge</artifactId>
-    
     <name>HK2 Guice Bridge</name>
     <description>${project.name}</description>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -54,8 +53,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/hk2-api/pom.xml
+++ b/hk2-api/pom.xml
@@ -27,8 +27,8 @@
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-api</artifactId>
     <name>HK2 API module</name>
-
     <description>${project.name}</description>
+
     <build>
         <plugins>
             <plugin>
@@ -66,8 +66,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -73,8 +73,9 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/hk2-jmx/pom.xml
+++ b/hk2-jmx/pom.xml
@@ -57,8 +57,9 @@
             <artifactId>osgi-resource-locator</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -24,7 +24,6 @@
         <artifactId>hk2-parent</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
     </parent>
-
     <artifactId>hk2-locator</artifactId>
     <name>ServiceLocator Default Implementation</name>
     <description>${project.name}</description>
@@ -63,9 +62,9 @@
         </plugins>
     </build>
     <dependencies>
-		 <dependency>
+        <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-metadata-generator/main/pom.xml
+++ b/hk2-metadata-generator/main/pom.xml
@@ -51,7 +51,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-metadata-generator/test1/pom.xml
+++ b/hk2-metadata-generator/test1/pom.xml
@@ -24,7 +24,6 @@
         <artifactId>hk2-metadata-generator-parent</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
     </parent>
-
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-metadata-generator-test1</artifactId>
     <name>HK2 Metadata Generator Test One</name>
@@ -45,7 +44,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -25,7 +25,6 @@
         <version>2.5.0-b63-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>hk2-junitrunner</artifactId>
     <name>HK2 Junit Runner</name>
     <description>A utility for running HK2 tests</description>
@@ -69,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/hk2-locator-extras/pom.xml
+++ b/hk2-testing/hk2-locator-extras/pom.xml
@@ -25,7 +25,6 @@
         <version>2.5.0-b63-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>hk2-locator-extras</artifactId>
     <name>HK2 Locator unit tests</name>
     <description>Extra unit tests for the HK2 Locator implementation</description>
@@ -65,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/hk2-locator-no-proxies/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies/pom.xml
@@ -25,7 +25,6 @@
         <version>2.5.0-b63-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>hk2-locator-no-proxies</artifactId>
     <name>HK2 Locator No Proxy Unit tests</name>
     <description>Tests the basic HK2 locator with no proxiable scopes</description>
@@ -58,14 +57,14 @@
             <artifactId>hk2-locator</artifactId>
             <version>${project.version}</version>
             <exclusions>
-              <exclusion>
-                <groupId>org.javassist</groupId>
-                <artifactId>javassist</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.glassfish.hk2.external</groupId>
-                <artifactId>aopalliance-repackaged</artifactId>
-              </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>aopalliance-repackaged</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -73,15 +72,15 @@
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
             <exclusions>
-              <exclusion>
-                <groupId>org.glassfish.hk2.external</groupId>
-                <artifactId>aopalliance-repackaged</artifactId>
-              </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>aopalliance-repackaged</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/hk2-testing/hk2-locator-no-proxies2/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies2/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/hk2-testing/hk2-mockito/pom.xml
+++ b/hk2-testing/hk2-mockito/pom.xml
@@ -24,7 +24,6 @@
         <artifactId>hk2-testing</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
     </parent>
-
     <artifactId>hk2-mockito</artifactId>
     <name>HK2 Mockito</name>
     <description>A utility for spying on HK2 services using Mockito</description>
@@ -70,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/hk2-runlevel-extras/pom.xml
+++ b/hk2-testing/hk2-runlevel-extras/pom.xml
@@ -25,7 +25,6 @@
         <version>2.5.0-b63-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>hk2-runlevel-extras</artifactId>
     <name>HK2 RunLevel unit tests</name>
     <description>Extra unit tests for the HK2 RunLevelService implementation</description>
@@ -64,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/hk2-testng/pom.xml
+++ b/hk2-testing/hk2-testng/pom.xml
@@ -18,14 +18,12 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-parent</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>hk2-testng</artifactId>
     <name>HK2 TestNG runner</name>
     <description>A utility for running HK2 under TestNG</description>
@@ -47,17 +45,17 @@
     </build>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
-       </dependency>
-       <dependency>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-extras</artifactId>
             <version>${project.version}</version>
         </dependency>
-       <dependency>
+        <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-locator</artifactId>
             <version>${project.version}</version>
@@ -69,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/interceptor-events/pom.xml
+++ b/hk2-testing/interceptor-events/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-testing/jersey/jersey-guice/form-param/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/form-param/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hk2-utils/pom.xml
+++ b/hk2-utils/pom.xml
@@ -27,8 +27,8 @@
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-utils</artifactId>
     <name>HK2 Implementation Utilities</name>
-
     <description>${project.name}</description>
+
     <build>
         <plugins>
             <plugin>
@@ -71,7 +71,7 @@
                     <unpackBundle>true</unpackBundle>
                 </configuration>
             </plugin>
-	    </plugins>
+        </plugins>
     </build>
 
     <dependencies>
@@ -80,13 +80,14 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
-        	<groupId>javax.validation</groupId>
-        	<artifactId>validation-api</artifactId>
-        	<optional>true</optional>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -106,7 +106,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/osgi/adapter-tests/no-hk2-bundle/pom.xml
+++ b/osgi/adapter-tests/no-hk2-bundle/pom.xml
@@ -55,7 +55,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <artifactId>jakarta.inject</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -23,7 +23,6 @@
         <artifactId>osgi-adapter-tests-parent</artifactId>
         <version>2.5.0-b63-SNAPSHOT</version>
     </parent>
-
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>osgi-adapter-test</artifactId>
     <name>HK2 OSGi Adapter Test</name>
@@ -104,12 +103,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>javax.inject</groupId>
-           <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
-
         <!-- Pax-Exam dependencies -->
-       
+
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-container-native</artifactId>
@@ -133,11 +132,11 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
-	    <exclusions>
-       		 <exclusion>
-          	 <groupId>avalon-framework</groupId>
-         	 <artifactId>avalon-framework-api</artifactId>
-            	 </exclusion>
+            <exclusions>
+                <exclusion>
+                    <groupId>avalon-framework</groupId>
+                    <artifactId>avalon-framework-api</artifactId>
+                </exclusion>
             </exclusions> 
         </dependency>
         <dependency>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -26,10 +26,9 @@
     </parent>
     <groupId>org.glassfish.hk2</groupId>
     <artifactId>spring-bridge</artifactId>
-    
     <name>HK2 Spring Bridge</name>
     <description>${project.name}</description>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -54,8 +53,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>jakarta.inject</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>


### PR DESCRIPTION
fix broken renaming of org.glassfish.hk2.external:javax.inject to org.glassfish.hk2.external:jakarta.inject