### PR TITLE
Add support for java.util.Optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,4 +2,4 @@ Changes since 2.5.0:
 
 * OperationHandle and ServiceHandle extend Closable for try-with-resources
 * Renamed Module to HK2Module for JDK 9+ compatibility
-
+* Added support for java.util.Optional as alternative to @Optional

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -55,6 +55,7 @@
                        cache in order to increase code coverage
                     -->
                     <argLine>-Dlocal.repo=${settings.localRepository} -Dbuild.dir=${project.build.directory} -Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/policy.txt -Dorg.jvnet.hk2.properties.useSoftReference=false ${surefireArgLineExtra}</argLine>
+                    <trimStackTrace>false</trimStackTrace>
                     <!-- -Djava.security.debug=access,failure,domain -->
                 </configuration>
             </plugin>

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/OptionalActiveDescriptor.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/OptionalActiveDescriptor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019 Payara Service Ltd. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.jvnet.hk2.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.glassfish.hk2.api.DescriptorType;
+import org.glassfish.hk2.api.DescriptorVisibility;
+import org.glassfish.hk2.api.Injectee;
+import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
+
+/**
+ *
+ * @author jonathan coustick
+ */
+public class OptionalActiveDescriptor<T> extends AbstractActiveDescriptor<Optional> {
+    
+    private Injectee injectee;
+    private Type requiredType;
+    private ServiceLocatorImpl locator;
+    
+    /**
+     * For serialization
+     */
+    public OptionalActiveDescriptor() {
+        super();
+    }
+    
+    /*package-private*/ OptionalActiveDescriptor(Injectee injectee, ServiceLocatorImpl locator, Type requiredType) {
+        super(new HashSet<Type>(),
+                PerLookup.class,
+                null,
+                new HashSet<Annotation>(),
+                DescriptorType.CLASS,
+                DescriptorVisibility.NORMAL,
+                0,
+                null,
+                null,
+                locator.getPerLocatorUtilities().getAutoAnalyzerName(injectee.getInjecteeClass()),
+                null);
+        
+        this.requiredType = requiredType;
+        this.injectee = injectee;
+        this.locator = locator;
+    }
+
+    @Override
+    public Class<?> getImplementationClass() {
+        return Optional.class;
+    }
+
+    @Override
+    public Type getImplementationType() {
+        return Optional.class;
+    }
+
+    @Override
+    public Optional<T> create(ServiceHandle<?> root) {
+        Set<Annotation> qualifierAnnotations = getQualifierAnnotations();
+        Annotation[] optionalAdded = qualifierAnnotations.toArray(new Annotation[qualifierAnnotations.size()]);
+
+        ServiceHandle<T> handle = locator.getServiceHandle(requiredType, optionalAdded);
+        if (handle == null) {
+            return Optional.empty();
+        }
+        T service = handle.getService();
+        return Optional.ofNullable(service);
+    }
+    
+}

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -541,6 +541,9 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
             return new ConstantActiveDescriptor<Object>(value, this);
         }
+        if (java.util.Optional.class.equals(rawType)) {
+            return new OptionalActiveDescriptor(injectee, this, ReflectionHelper.getFirstTypeArgument(requiredType));
+        }
         
         if (Topic.class.equals(rawType)) {
             TopicImpl<?> value = new TopicImpl<Object>(this,

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/factory/DateInjectee.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/factory/DateInjectee.java
@@ -17,6 +17,7 @@
 package org.glassfish.hk2.tests.locator.factory;
 
 import java.util.Date;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -30,7 +31,9 @@ import javax.inject.Singleton;
 public class DateInjectee {
     @Inject private Date rawInject;
     @Inject private Provider<Date> providedInject;
+    @Inject private Optional<Date> optionalInject;
     
     public Date getRawInject() { return rawInject; }
     public Date getProvidedInject() { return providedInject.get(); }
+    public Date getOptionalInject() { return optionalInject.get(); }
 }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/factory/FactoryTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/factory/FactoryTest.java
@@ -82,6 +82,9 @@ public class FactoryTest {
         Date providedDate2 = dateInjectee.getProvidedInject();
         Assert.assertNotNull(providedDate2);
         
+        Date optionalDate = dateInjectee.getOptionalInject();
+        Assert.assertNotNull(optionalDate);
+        
         Assert.assertNotSame(rawDate, providedDate1);
         Assert.assertNotSame(rawDate, providedDate2);
         Assert.assertNotSame(providedDate1, providedDate2);

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
@@ -52,6 +52,9 @@ public class InjectedManyTimes {
     private java.util.Optional<SimpleService> simpleByContained;
     
     @Inject
+    private java.util.Optional<java.util.Optional<SimpleService>> simpleTwiceOptional;
+    
+    @Inject
     private java.util.Optional<Provider<OptionalService>> optionalByProviderContained;
     
     @Inject
@@ -119,6 +122,8 @@ public class InjectedManyTimes {
         
         Assert.assertFalse(optionalByContained.isPresent());
         Assert.assertTrue(simpleByContained.isPresent());
+        Assert.assertTrue(simpleTwiceOptional.get().isPresent());
+        
         Assert.assertTrue(optionalByProviderContained.isPresent());
         Assert.assertNull(optionalByProviderContained.get().get());
         Assert.assertEquals("testvalue", optionalProvided.get());

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
@@ -57,6 +57,12 @@ public class InjectedManyTimes {
     @Inject
     private java.util.Optional optionalProvided;
     
+    @Inject
+    private Widget nullWidget;
+    
+    @Inject
+    private java.util.Optional<Widget> optionalWidget;
+    
     private final SimpleService simpleByConstructor;
     private final OptionalService optionalByConstructor;
     
@@ -116,6 +122,9 @@ public class InjectedManyTimes {
         Assert.assertTrue(optionalByProviderContained.isPresent());
         Assert.assertNull(optionalByProviderContained.get().get());
         Assert.assertEquals("testvalue", optionalProvided.get());
+        
+        Assert.assertNull(nullWidget);
+        Assert.assertFalse(optionalWidget.isPresent());
         
         isValid = true;
     }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
@@ -45,6 +45,12 @@ public class InjectedManyTimes {
     @Inject @Optional
     private IterableProvider<OptionalService> optionalByIterableProvider;
     
+    @Inject
+    private java.util.Optional<OptionalService> optionalByContained;
+    
+    @Inject
+    private java.util.Optional<SimpleService> simpleByContained;
+    
     private final SimpleService simpleByConstructor;
     private final OptionalService optionalByConstructor;
     
@@ -98,6 +104,9 @@ public class InjectedManyTimes {
         
         Assert.assertNotNull(optionalByProvider);
         Assert.assertNull(optionalByProvider.get());
+        
+        Assert.assertFalse(optionalByContained.isPresent());
+        Assert.assertTrue(simpleByContained.isPresent());
         
         isValid = true;
     }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/InjectedManyTimes.java
@@ -51,6 +51,12 @@ public class InjectedManyTimes {
     @Inject
     private java.util.Optional<SimpleService> simpleByContained;
     
+    @Inject
+    private java.util.Optional<Provider<OptionalService>> optionalByProviderContained;
+    
+    @Inject
+    private java.util.Optional optionalProvided;
+    
     private final SimpleService simpleByConstructor;
     private final OptionalService optionalByConstructor;
     
@@ -107,6 +113,9 @@ public class InjectedManyTimes {
         
         Assert.assertFalse(optionalByContained.isPresent());
         Assert.assertTrue(simpleByContained.isPresent());
+        Assert.assertTrue(optionalByProviderContained.isPresent());
+        Assert.assertNull(optionalByProviderContained.get().get());
+        Assert.assertEquals("testvalue", optionalProvided.get());
         
         isValid = true;
     }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NullWidgetFactory.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NullWidgetFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Payara Service Ltd. and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.hk2.tests.locator.optional;
+
+import org.glassfish.hk2.api.Factory;
+
+/**
+ * A Factory that will always return null
+ * @author jonathan coustick
+ */
+public class NullWidgetFactory implements Factory<Widget> {
+
+    @Override
+    public Widget provide() {
+        return null;
+    }
+
+    @Override
+    public void dispose(Widget instance) {
+    }
+    
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/OptionalModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/OptionalModule.java
@@ -16,6 +16,7 @@
 
 package org.glassfish.hk2.tests.locator.optional;
 
+import java.util.Optional;
 import javax.inject.Singleton;
 
 import org.glassfish.hk2.api.DynamicConfiguration;
@@ -38,6 +39,10 @@ public class OptionalModule implements TestModule {
 
         configurator.bind(BuilderHelper.link(SimpleService.class).build());
         configurator.bind(BuilderHelper.link(InjectedManyTimes.class).in(Singleton.class.getName()).build());
+        
+        Optional<String> providedOptional = Optional.of("testvalue");
+        configurator.bind(BuilderHelper.createConstantDescriptor(providedOptional, null, Optional.class));
+        
     }
 
 }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/OptionalModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/OptionalModule.java
@@ -38,7 +38,8 @@ public class OptionalModule implements TestModule {
         // to ensure that optional injection points work
 
         configurator.bind(BuilderHelper.link(SimpleService.class).build());
-        configurator.bind(BuilderHelper.link(InjectedManyTimes.class).in(Singleton.class.getName()).build());
+        configurator.bind(BuilderHelper.link(InjectedManyTimes.class).in(Singleton.class).build());
+        configurator.bind(BuilderHelper.link(NullWidgetFactory.class).to(Widget.class).buildFactory());
         
         Optional<String> providedOptional = Optional.of("testvalue");
         configurator.bind(BuilderHelper.createConstantDescriptor(providedOptional, null, Optional.class));

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/Widget.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/Widget.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Payara Service Ltd. and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.hk2.tests.locator.optional;
+
+/**
+ *
+ * @author jonathan coustick
+ */
+public class Widget {
+    
+}


### PR DESCRIPTION
This includes all the features requested in #457 , allowing for injection of `Optional<Object>` instead of using the `@Optional` annotation.