### PR TITLE
Fix hk2-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,14 +20,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.5</version>
-        <relativePath />
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-parent</artifactId>
+        <version>2.6.1-SNAPSHOT</version>
     </parent>
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-bom</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>HK2 Bom Pom</name>
@@ -187,24 +184,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <scm>
-        <tag>HEAD</tag>
-    </scm>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.glassfish.copyright</groupId>
-                    <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.42</version>
-                    <configuration>
-                        <scm>git</scm>
-                        <scmOnly>true</scmOnly>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -513,11 +513,6 @@
                     <artifactId>depends-maven-plugin</artifactId>
                     <version>1.4.0</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.servicemix.tooling</groupId>
-                    <artifactId>depends-maven-plugin</artifactId>
-                    <version>1.4.0</version>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Fixes #470 

made hk2-bom depend on hk2-parent.
Removed duplicate plugin entry for org.apache.servicemix.tooling