### PR TITLE
Nested dependencies testing

### DIFF
--- a/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/HK2JunitRunner.java
+++ b/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/HK2JunitRunner.java
@@ -1,0 +1,55 @@
+package org.jvnet.hk2.testing.junit;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.Filterable;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.jvnet.hk2.testing.junit.internal.TestServiceLocator;
+
+/**
+ * Runner class for having injected services inside of tests using the @RunWith annotation.
+ *
+ * @author Attila Houtkooper
+ */
+public class HK2JunitRunner extends Runner implements Filterable {
+    private BlockJUnit4ClassRunner runner;
+
+    public HK2JunitRunner(Class<?> testClass) throws InitializationError {
+        runner = new BlockJUnit4ClassRunner(testClass) {
+            @Override
+            protected Statement withBefores(FrameworkMethod method, Object target, Statement statement) {
+                Statement base = super.withBefores(method, target, statement);
+
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        TestServiceLocator testServiceLocator = new TestServiceLocator(target);
+                        testServiceLocator.initializeOnBefore();
+                        base.evaluate();
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public Description getDescription() {
+        return runner.getDescription();
+    }
+
+    @Override
+    public void run(RunNotifier runNotifier) {
+        runner.run(runNotifier);
+    }
+
+    @Override
+    public void filter(Filter filter) throws NoTestsRemainException {
+        runner.filter(filter);
+    }
+}

--- a/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/HK2Runner.java
+++ b/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/HK2Runner.java
@@ -16,41 +16,15 @@
 
 package org.jvnet.hk2.testing.junit;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
-import org.glassfish.hk2.api.DynamicConfiguration;
-import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.hk2.api.ServiceLocatorFactory;
-import org.glassfish.hk2.utilities.DescriptorImpl;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.junit.Before;
 import org.jvnet.hk2.testing.junit.annotations.Classes;
 import org.jvnet.hk2.testing.junit.annotations.Excludes;
-import org.jvnet.hk2.testing.junit.annotations.InhabitantFiles;
 import org.jvnet.hk2.testing.junit.annotations.Packages;
-import org.jvnet.hk2.testing.junit.internal.ClassVisitorImpl;
-import org.jvnet.hk2.testing.junit.internal.ErrorServiceImpl;
-import org.jvnet.hk2.testing.junit.internal.JustInTimeInjectionResolverImpl;
-import org.objectweb.asm.ClassReader;
+import org.jvnet.hk2.testing.junit.internal.TestServiceLocator;
 
 /**
  * This class should be extended by test classes in order to get an automatically
@@ -82,18 +56,16 @@ import org.objectweb.asm.ClassReader;
  * @author jwells
  */
 public class HK2Runner {
-    private final static String CLASS_PATH_PROP = "java.class.path";
-    private final static String DOT_CLASS = ".class";
+    private TestServiceLocator testServiceLocator;
     
     /**
      * Test classes can use this service locator as their private test locator
      */
     protected ServiceLocator testLocator;
-    
-    /**
-     * The verbosity of this runner
-     */
-    private boolean verbose = false;
+
+    public HK2Runner() {
+        testServiceLocator = new TestServiceLocator(this);
+    }
     
     /**
      * This will generate the default testLocator for this test
@@ -102,15 +74,8 @@ public class HK2Runner {
      */
     @Before
     public void before() {
-        Packages packages = getClass().getAnnotation(Packages.class);
-        if (packages == null) {
-            initialize(getClass().getName(), 
-                Collections.singletonList(getClass().getPackage().getName()),
-                null, null, null);
-        }
-        else {
-            initialize(null, null, null, null, null);
-        }
+        testServiceLocator.initializeOnBefore();
+        testLocator = testServiceLocator.getServiceLocator();
     }
     
     /**
@@ -120,7 +85,8 @@ public class HK2Runner {
      * {@link Packages}, {@link Classes}, {@link Excludes}, @{link InhabitantFiles}
      */
     public void initialize() {
-        initialize(null, null, null, null, null);
+        testServiceLocator.initialize();
+        testLocator = testServiceLocator.getServiceLocator();
     }
 
     /**
@@ -137,7 +103,8 @@ public class HK2Runner {
      * &#64;Service or not.  If null this is considered to be the empty set
      */
     protected void initialize(String name, List<String> packages, List<Class<?>> clazzes) {
-        initialize(name, packages, clazzes, null, null);
+        testServiceLocator.initialize(name, packages, clazzes);
+        testLocator = testServiceLocator.getServiceLocator();
     }
     
     /**
@@ -157,63 +124,8 @@ public class HK2Runner {
      * things coming from packages or from the hk2-locator/default file
      */
     protected void initialize(String name, List<String> packages, List<Class<?>> clazzes, Set<String> excludes) {
-        initialize(name, packages, clazzes, excludes, null);
-    }
-    
-    private List<String> getDefaultPackages() {
-        Packages packages = getClass().getAnnotation(Packages.class);
-        if (packages == null) return Collections.emptyList();
-        
-        List<String> retVal = new ArrayList<String>(packages.value().length);
-        for (String pack : packages.value()) {
-            if (Packages.THIS_PACKAGE.equals(pack)) {
-                retVal.add(getClass().getPackage().getName());
-            }
-            else {
-                retVal.add(pack);
-            }
-        }
-        
-        return retVal;
-    }
-    
-    private List<Class<?>> getDefaultClazzes() {
-        Classes clazzes = getClass().getAnnotation(Classes.class);
-        if (clazzes == null) return Collections.emptyList();
-        
-        List<Class<?>> retVal = new ArrayList<Class<?>>(clazzes.value().length);
-        for (Class<?> clazz : clazzes.value()) {
-            retVal.add(clazz);
-        }
-        
-        return retVal;
-    }
-    
-    private Set<String> getDefaultExcludes() {
-        Excludes excludes = getClass().getAnnotation(Excludes.class);
-        if (excludes == null) return Collections.emptySet();
-        
-        Set<String> retVal = new HashSet<String>();
-        for (String exclude : excludes.value()) {
-            retVal.add(exclude);
-        }
-        
-        return retVal;
-    }
-    
-    private Set<String> getDefaultLocatorFiles() {
-        HashSet<String> retVal = new HashSet<String>();
-        InhabitantFiles iFiles = getClass().getAnnotation(InhabitantFiles.class);
-        if (iFiles == null) {
-            retVal.add("META-INF/hk2-locator/default");
-            return retVal;
-        }
-        
-        for (String iFile : iFiles.value()) {
-            retVal.add(iFile);
-        }
-        
-        return retVal;
+        testServiceLocator.initialize(name, packages, clazzes, excludes);
+        testLocator = testServiceLocator.getServiceLocator();
     }
     
     /**
@@ -237,251 +149,11 @@ public class HK2Runner {
      * values those will be searched as resources from the jars in the classpath to load the registry with
      */
     protected void initialize(String name, List<String> packages, List<Class<?>> clazzes, Set<String> excludes, Set<String> locatorFiles) {
-        if (name == null) name = getClass().getName();
-        if (packages == null) packages = getDefaultPackages();
-        if (clazzes == null) clazzes = getDefaultClazzes();
-        if (excludes == null) excludes = getDefaultExcludes();
-        if (locatorFiles == null) locatorFiles = getDefaultLocatorFiles();
-        
-        ServiceLocator found = ServiceLocatorFactory.getInstance().find(name);
-        if (found != null) {
-            testLocator = found;
-            
-            testLocator.inject(this);
-            return;
-        }
-        
-        testLocator = ServiceLocatorFactory.getInstance().create(name);
-        
-        ServiceLocatorUtilities.addClasses(testLocator, ErrorServiceImpl.class);
-        final JustInTimeInjectionResolverImpl jitResolver = new JustInTimeInjectionResolverImpl(excludes);
-        testLocator.inject(jitResolver);
-        ServiceLocatorUtilities.addOneConstant(testLocator, jitResolver);
-        
-        DynamicConfigurationService dcs = testLocator.getService(DynamicConfigurationService.class);
-        DynamicConfiguration config = dcs.createDynamicConfiguration();
-        
-        addServicesFromDefault(config, excludes, locatorFiles);
-        
-        addServicesFromPackage(config, packages, excludes);
-        
-        for (Class<?> clazz : clazzes) {
-            config.addActiveDescriptor(clazz);
-        }
-        
-        config.commit();
-        
-        testLocator.inject(this);
+        testServiceLocator.initialize(name, packages, clazzes, excludes, locatorFiles);
+        testLocator = testServiceLocator.getServiceLocator();
     }
     
     protected void setVerbosity(boolean verbose) {
-        this.verbose = verbose;
-    }
-    
-    private void addServicesFromDefault(final DynamicConfiguration config, final Set<String> excludes, final Set<String> locatorFiles) {
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-
-            @Override
-            public Object run() {
-                internalAddServicesFromDefault(config, excludes, locatorFiles);
-                return null;
-            }
-            
-        });
-    }
-    
-    private void readResources(Enumeration<URL> resources, Set<String> excludes, DynamicConfiguration config) {
-        while (resources.hasMoreElements()) {
-            URL url = resources.nextElement();
-           
-            try {
-                InputStream urlStream = url.openStream();
-                
-                BufferedReader reader = new BufferedReader(new InputStreamReader(urlStream));
-                
-                boolean goOn = true;
-                while (goOn) {
-                    DescriptorImpl bindMe = new DescriptorImpl();
-                
-                    goOn = bindMe.readObject(reader);
-                    if (goOn == true && !excludes.contains(bindMe.getImplementation())) {
-                        config.bind(bindMe);
-                    }
-                }
-                
-                reader.close();
-            }
-            catch (IOException ioe) {
-                ioe.printStackTrace();
-                
-                continue;
-            }
-            
-            
-        }
-        
-    }
-    
-    private void internalAddServicesFromDefault(DynamicConfiguration config, Set<String> excludes, Set<String> locatorFiles) {
-        ClassLoader loader = this.getClass().getClassLoader();
-        
-        for (String locatorFile : locatorFiles) {
-            Enumeration<URL> resources;
-            try {
-                resources = loader.getResources(locatorFile);
-            }
-            catch (IOException ioe) {
-                ioe.printStackTrace();
-            
-                return;
-            }
-            
-            readResources(resources, excludes, config);
-        }
-    }
-    
-    private void addServicesFromPackage(final DynamicConfiguration config, final List<String> packages, final Set<String> excludes) {
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-
-            @Override
-            public Object run() {
-                internalAddServicesFromPackage(config, packages, excludes);
-                return null;
-            }
-            
-        });
-    }
-    
-    private void internalAddServicesFromPackage(DynamicConfiguration config, List<String> packages, Set<String> excludes) {
-        if (packages.isEmpty()) {
-            return;
-        }
-        
-        String classPath = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            public String run() {
-                return System.getProperty(CLASS_PATH_PROP);
-            }
-                
-        });
-        
-        StringTokenizer st = new StringTokenizer(classPath, File.pathSeparator);
-        
-        while(st.hasMoreTokens()) {
-            String pathElement = st.nextToken();
-            
-            addServicesFromPathElement(config, packages, pathElement, excludes);
-        }
-        
-    }
-    
-    private void addServicesFromPathElement(DynamicConfiguration config, List<String> packages, String element, Set<String> excludes) {
-        File fileElement = new File(element);
-        if (!fileElement.exists()) return;
-        
-        if (fileElement.isDirectory()) {
-            addServicesFromPathDirectory(config, packages, fileElement, excludes);
-        }
-        else {
-            addServicesFromPathJar(config, packages, fileElement, excludes);
-        }
-    }
-    
-    private void addServicesFromPathDirectory(DynamicConfiguration config, List<String> packages, File directory, Set<String> excludes) {
-        for (String pack : packages) {
-            File searchDir = new File(directory, convertToFileFormat(pack));
-            if (!searchDir.exists()) continue;
-            if (!searchDir.isDirectory()) continue;
-            
-            File candidates[] = searchDir.listFiles(new FilenameFilter() {
-
-                @Override
-                public boolean accept(File dir, String name) {
-                    if (name == null) return false;
-                    if (name.endsWith(DOT_CLASS)) return true;
-                    return false;
-                }
-                
-            });
-            
-            if (candidates == null) continue;
-            
-            for (File candidate : candidates) {
-                try {
-                    FileInputStream fis = new FileInputStream(candidate);
-                    
-                    addClassIfService(fis, excludes);
-                }
-                catch (IOException ioe) {
-                    // Just don't add it
-                }
-            }
-        }
-        
-    }
-    
-    private void addServicesFromPathJar(DynamicConfiguration config, List<String> packages, File jar, Set<String> excludes) {
-        JarFile jarFile;
-        try {
-            jarFile = new JarFile(jar);
-        }
-        catch (IOException ioe) {
-            // Not a jar file, forget it
-            return;
-        }
-        
-        try {
-            for (String pack : packages) {
-                String packAsFile = convertToFileFormat(pack);
-                int packAsFileLen = packAsFile.length() + 1;
-            
-                Enumeration<JarEntry> entries = jarFile.entries();
-                while (entries.hasMoreElements()) {
-                    JarEntry entry = entries.nextElement();
-                
-                    String entryName = entry.getName();
-                    if (!entryName.startsWith(packAsFile)) {
-                        // Not in the correct directory
-                        continue;
-                    }
-                    if (entryName.substring(packAsFileLen).contains("/")) {
-                        // Next directory down
-                        continue;
-                    }
-                    if (!entryName.endsWith(DOT_CLASS)) {
-                        // Not a class
-                        continue;
-                    }
-                
-                    try {
-                        addClassIfService(jarFile.getInputStream(entry), excludes);
-                    }
-                    catch (IOException ioe) {
-                        // Simply don't add it if we can't read it
-                    }
-                }
-            }
-        }
-        finally {
-            try {
-                jarFile.close();
-            }
-            catch (IOException e) {
-                // Ignore
-            }
-        }
-    }
-    
-    private void addClassIfService(InputStream is, Set<String> excludes) throws IOException {
-        ClassReader reader = new ClassReader(is);
-        
-        ClassVisitorImpl cvi = new ClassVisitorImpl(testLocator, verbose, excludes);
-        
-        reader.accept(cvi, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
-        
-    }
-    
-    private static String convertToFileFormat(String clazzFormat) {
-        return clazzFormat.replaceAll("\\.", "/");
+        testServiceLocator.setVerbosity(verbose);
     }
 }

--- a/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/internal/TestServiceLocator.java
+++ b/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/internal/TestServiceLocator.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.jvnet.hk2.testing.junit.internal;
+
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.DynamicConfigurationService;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.DescriptorImpl;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.jvnet.hk2.testing.junit.annotations.Classes;
+import org.jvnet.hk2.testing.junit.annotations.Excludes;
+import org.jvnet.hk2.testing.junit.annotations.InhabitantFiles;
+import org.jvnet.hk2.testing.junit.annotations.Packages;
+import org.objectweb.asm.ClassReader;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * This class should be extended by test classes in order to get an automatically
+ * filled in ServiceLocator.  By default the testLocator will inspect the package
+ * of the test to find any classes annotated with &#64;Service.  The locator will
+ * also be able to do second-chance advertisement of services that were injected.
+ * The default ServiceLocator will also have an error handler that causes any classloading
+ * failure to get rethrown up to the lookup call, since this can sometimes cause
+ * confusion.
+ * <p>
+ * The behavior of HK2Runner can be customized by annotating the class extending
+ * HK2Runner with {@link Packages},
+ * {@link Classes}, {@link Excludes}
+ * or {@link InhabitantFiles}.
+ * <p>
+ * {@link Packages} gives the names of packages
+ * that will automatically be scanned for classes that should be added to testLocator
+ * as services.  {@link Classes} gives an
+ * explicit set of classes that should be added to testLocator as services.
+ * {@link Excludes} gives a set of services
+ * that should not be automatically added to the testLocator.
+ * {@link InhabitantFiles} gives a set of
+ * inhabitant files to load in the classpath of the test.
+ * <p>
+ * This behavior can be customized by overriding the before method of the test and calling one
+ * of the {@link #initialize(String, List, List)} methods.  The annotations listed above
+ * are overridden by any values passed to the initialize methods
+ *
+ * @author jwells
+ */
+public class TestServiceLocator {
+    private final static String CLASS_PATH_PROP = "java.class.path";
+    private final static String DOT_CLASS = ".class";
+
+    /**
+     * Test classes can use this service locator as their private test locator
+     */
+    private ServiceLocator serviceLocator;
+
+    /**
+     * The verbosity of this runner
+     */
+    private boolean verbose = false;
+
+    private Object test;
+    private Class<?> testClass;
+
+    /**
+     * This will generate the default testLocator for this test
+     * class, which will search the package of the test itself for
+     * classes annotated with &#64;Service.
+     */
+    public TestServiceLocator(Object test) {
+        this.test = test;
+        testClass = test.getClass();
+    }
+
+    public void initializeOnBefore() {
+        Packages packages = testClass.getAnnotation(Packages.class);
+
+        if (packages == null) {
+            initialize(testClass.getName(),
+                    Collections.singletonList(testClass.getPackage().getName()),
+                    null, null, null);
+        } else {
+            initialize(null, null, null, null, null);
+        }
+    }
+
+    public ServiceLocator getServiceLocator() {
+        return serviceLocator;
+    }
+
+    /**
+     * This method initializes the service locator with services.  The name
+     * of the locator will be the fully qualified name of the class.  All
+     * other values will either be empty or will come from the annotations
+     * {@link Packages}, {@link Classes}, {@link Excludes}, @{link InhabitantFiles}
+     */
+    public void initialize() {
+        initialize(null, null, null, null, null);
+    }
+
+    /**
+     * This method initializes the service locator with services from the given list
+     * of packages (in "." format) and with the set of classes given.
+     *
+     * @param name     The name of the service locator to create.  If there is already a
+     *                 service locator of this name then the remaining fields will be ignored and the existing
+     *                 locator with this name will be returned.  May not be null
+     * @param packages The list of packages (in "." format, i.e. "com.acme.test.services") that
+     *                 we should hunt through the classpath for in order to find services.  If null this is considered
+     *                 to be the empty set
+     * @param clazzes  A set of classes that should be analyzed as services, whether they declare
+     *                 &#64;Service or not.  If null this is considered to be the empty set
+     */
+    public void initialize(String name, List<String> packages, List<Class<?>> clazzes) {
+        initialize(name, packages, clazzes, null, null);
+    }
+
+    /**
+     * This method initializes the service locator with services from the given list
+     * of packages (in "." format) and with the set of classes given.
+     *
+     * @param name     The name of the service locator to create.  If there is already a
+     *                 service locator of this name then the remaining fields will be ignored and the existing
+     *                 locator with this name will be returned.  May not be null
+     * @param packages The list of packages (in "." format, i.e. "com.acme.test.services") that
+     *                 we should hunt through the classpath for in order to find services.  If null this is considered
+     *                 to be the empty set
+     * @param clazzes  A set of classes that should be analyzed as services, whether they declare
+     *                 &#64;Service or not.  If null this is considered to be the empty set
+     * @param excludes A set of implementations that should be excluded from being added.  This list is
+     *                 NOT checked against the clazzes list (the explicit include wins), but instead against the set of
+     *                 things coming from packages or from the hk2-locator/default file
+     */
+    public void initialize(String name, List<String> packages, List<Class<?>> clazzes, Set<String> excludes) {
+        initialize(name, packages, clazzes, excludes, null);
+    }
+
+    private List<String> getDefaultPackages() {
+        Packages packages = testClass.getAnnotation(Packages.class);
+        if (packages == null) return Collections.emptyList();
+
+        List<String> retVal = new ArrayList<String>(packages.value().length);
+        for (String pack : packages.value()) {
+            if (Packages.THIS_PACKAGE.equals(pack)) {
+                retVal.add(testClass.getPackage().getName());
+            } else {
+                retVal.add(pack);
+            }
+        }
+
+        return retVal;
+    }
+
+    private List<Class<?>> getDefaultClazzes() {
+        Classes clazzes = testClass.getAnnotation(Classes.class);
+        if (clazzes == null) return Collections.emptyList();
+
+        List<Class<?>> retVal = new ArrayList<Class<?>>(clazzes.value().length);
+        for (Class<?> clazz : clazzes.value()) {
+            retVal.add(clazz);
+        }
+
+        return retVal;
+    }
+
+    private Set<String> getDefaultExcludes() {
+        Excludes excludes = testClass.getAnnotation(Excludes.class);
+        if (excludes == null) return Collections.emptySet();
+
+        Set<String> retVal = new HashSet<String>();
+        for (String exclude : excludes.value()) {
+            retVal.add(exclude);
+        }
+
+        return retVal;
+    }
+
+    private Set<String> getDefaultLocatorFiles() {
+        HashSet<String> retVal = new HashSet<String>();
+        InhabitantFiles iFiles = testClass.getAnnotation(InhabitantFiles.class);
+        if (iFiles == null) {
+            retVal.add("META-INF/hk2-locator/default");
+            return retVal;
+        }
+
+        for (String iFile : iFiles.value()) {
+            retVal.add(iFile);
+        }
+
+        return retVal;
+    }
+
+    /**
+     * This method initializes the service locator with services from the given list
+     * of packages (in "." format) and with the set of classes given.
+     *
+     * @param name         The name of the service locator to create.  If there is already a
+     *                     service locator of this name then the remaining fields will be ignored and the existing
+     *                     locator with this name will be returned.  May not be null
+     * @param packages     The list of packages (in "." format, i.e. "com.acme.test.services") that
+     *                     we should hunt through the classpath for in order to find services.  If null this is considered
+     *                     to be the empty set
+     * @param clazzes      A set of classes that should be analyzed as services, whether they declare
+     *                     &#64;Service or not.  If null this is considered to be the empty set
+     * @param excludes     A set of implementations that should be excluded from being added.  This list is
+     *                     NOT checked against the clazzes list (the explicit include wins), but instead against the set of
+     *                     things coming from packages or from the hk2-locator/default file
+     * @param locatorFiles A set of locator inhabitant files to search the classpath for to load.  If
+     *                     this value is null then only META-INF/hk2-locator/default files on the classpath will be searched.
+     *                     If this value is an empty set then no inhabitant files will be loaded.  If this value contains
+     *                     values those will be searched as resources from the jars in the classpath to load the registry with
+     */
+    public void initialize(String name, List<String> packages, List<Class<?>> clazzes, Set<String> excludes, Set<String> locatorFiles) {
+        if (name == null) name = testClass.getName();
+        if (packages == null) packages = getDefaultPackages();
+        if (clazzes == null) clazzes = getDefaultClazzes();
+        if (excludes == null) excludes = getDefaultExcludes();
+        if (locatorFiles == null) locatorFiles = getDefaultLocatorFiles();
+
+        ServiceLocator found = ServiceLocatorFactory.getInstance().find(name);
+        if (found != null) {
+            serviceLocator = found;
+            serviceLocator.inject(test);
+            return;
+        }
+
+        serviceLocator = ServiceLocatorFactory.getInstance().create(name);
+
+        ServiceLocatorUtilities.addClasses(serviceLocator, ErrorServiceImpl.class);
+        final JustInTimeInjectionResolverImpl jitResolver = new JustInTimeInjectionResolverImpl(excludes);
+        serviceLocator.inject(jitResolver);
+        ServiceLocatorUtilities.addOneConstant(serviceLocator, jitResolver);
+
+        DynamicConfigurationService dcs = serviceLocator.getService(DynamicConfigurationService.class);
+        DynamicConfiguration config = dcs.createDynamicConfiguration();
+
+        addServicesFromDefault(config, excludes, locatorFiles);
+
+        addServicesFromPackage(config, packages, excludes);
+
+        for (Class<?> clazz : clazzes) {
+            config.addActiveDescriptor(clazz);
+        }
+
+        config.commit();
+
+        serviceLocator.inject(test);
+    }
+
+    public void setVerbosity(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    private void addServicesFromDefault(final DynamicConfiguration config, final Set<String> excludes, final Set<String> locatorFiles) {
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+
+            @Override
+            public Object run() {
+                internalAddServicesFromDefault(config, excludes, locatorFiles);
+                return null;
+            }
+
+        });
+    }
+
+    private void readResources(Enumeration<URL> resources, Set<String> excludes, DynamicConfiguration config) {
+        while (resources.hasMoreElements()) {
+            URL url = resources.nextElement();
+
+            try {
+                InputStream urlStream = url.openStream();
+
+                BufferedReader reader = new BufferedReader(new InputStreamReader(urlStream));
+
+                boolean goOn = true;
+                while (goOn) {
+                    DescriptorImpl bindMe = new DescriptorImpl();
+
+                    goOn = bindMe.readObject(reader);
+                    if (goOn == true && !excludes.contains(bindMe.getImplementation())) {
+                        config.bind(bindMe);
+                    }
+                }
+
+                reader.close();
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+
+                continue;
+            }
+
+
+        }
+
+    }
+
+    private void internalAddServicesFromDefault(DynamicConfiguration config, Set<String> excludes, Set<String> locatorFiles) {
+        ClassLoader loader = testClass.getClassLoader();
+
+        for (String locatorFile : locatorFiles) {
+            Enumeration<URL> resources;
+            try {
+                resources = loader.getResources(locatorFile);
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+
+                return;
+            }
+
+            readResources(resources, excludes, config);
+        }
+    }
+
+    private void addServicesFromPackage(final DynamicConfiguration config, final List<String> packages, final Set<String> excludes) {
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+
+            @Override
+            public Object run() {
+                internalAddServicesFromPackage(config, packages, excludes);
+                return null;
+            }
+
+        });
+    }
+
+    private void internalAddServicesFromPackage(DynamicConfiguration config, List<String> packages, Set<String> excludes) {
+        if (packages.isEmpty()) {
+            return;
+        }
+
+        String classPath = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getProperty(CLASS_PATH_PROP);
+            }
+
+        });
+
+        StringTokenizer st = new StringTokenizer(classPath, File.pathSeparator);
+
+        while (st.hasMoreTokens()) {
+            String pathElement = st.nextToken();
+
+            addServicesFromPathElement(config, packages, pathElement, excludes);
+        }
+
+    }
+
+    private void addServicesFromPathElement(DynamicConfiguration config, List<String> packages, String element, Set<String> excludes) {
+        File fileElement = new File(element);
+        if (!fileElement.exists()) return;
+
+        if (fileElement.isDirectory()) {
+            addServicesFromPathDirectory(config, packages, fileElement, excludes);
+        } else {
+            addServicesFromPathJar(config, packages, fileElement, excludes);
+        }
+    }
+
+    private void addServicesFromPathDirectory(DynamicConfiguration config, List<String> packages, File directory, Set<String> excludes) {
+        for (String pack : packages) {
+            File searchDir = new File(directory, convertToFileFormat(pack));
+            if (!searchDir.exists()) continue;
+            if (!searchDir.isDirectory()) continue;
+
+            File candidates[] = searchDir.listFiles(new FilenameFilter() {
+
+                @Override
+                public boolean accept(File dir, String name) {
+                    if (name == null) return false;
+                    if (name.endsWith(DOT_CLASS)) return true;
+                    return false;
+                }
+
+            });
+
+            if (candidates == null) continue;
+
+            for (File candidate : candidates) {
+                try {
+                    FileInputStream fis = new FileInputStream(candidate);
+
+                    addClassIfService(fis, excludes);
+                } catch (IOException ioe) {
+                    // Just don't add it
+                }
+            }
+        }
+
+    }
+
+    private void addServicesFromPathJar(DynamicConfiguration config, List<String> packages, File jar, Set<String> excludes) {
+        JarFile jarFile;
+        try {
+            jarFile = new JarFile(jar);
+        } catch (IOException ioe) {
+            // Not a jar file, forget it
+            return;
+        }
+
+        try {
+            for (String pack : packages) {
+                String packAsFile = convertToFileFormat(pack);
+                int packAsFileLen = packAsFile.length() + 1;
+
+                Enumeration<JarEntry> entries = jarFile.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+
+                    String entryName = entry.getName();
+                    if (!entryName.startsWith(packAsFile)) {
+                        // Not in the correct directory
+                        continue;
+                    }
+                    if (entryName.substring(packAsFileLen).contains("/")) {
+                        // Next directory down
+                        continue;
+                    }
+                    if (!entryName.endsWith(DOT_CLASS)) {
+                        // Not a class
+                        continue;
+                    }
+
+                    try {
+                        addClassIfService(jarFile.getInputStream(entry), excludes);
+                    } catch (IOException ioe) {
+                        // Simply don't add it if we can't read it
+                    }
+                }
+            }
+        } finally {
+            try {
+                jarFile.close();
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+    }
+
+    private void addClassIfService(InputStream is, Set<String> excludes) throws IOException {
+        ClassReader reader = new ClassReader(is);
+
+        ClassVisitorImpl cvi = new ClassVisitorImpl(serviceLocator, verbose, excludes);
+
+        reader.accept(cvi, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+
+    }
+
+    private static String convertToFileFormat(String clazzFormat) {
+        return clazzFormat.replaceAll("\\.", "/");
+    }
+}

--- a/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/JunitRunnerTest.java
+++ b/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/JunitRunnerTest.java
@@ -1,0 +1,21 @@
+package org.jvnet.hk2.testing.test;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hk2.testing.junit.HK2JunitRunner;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HK2JunitRunner.class)
+public class JunitRunnerTest {
+
+    @Inject
+    private SimpleService injectMe;
+
+    @Test
+    public void testServiceInjection() {
+        assertNotNull(injectMe);
+    }
+}

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/HK2MockitoInjectionResolver.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/HK2MockitoInjectionResolver.java
@@ -63,7 +63,7 @@ public class HK2MockitoInjectionResolver implements InjectionResolver<Inject> {
         parentCache.put(requiredType, parentType);
 
         if (sut != null) {
-            service = mockitoService.findOrCreateSUT(sut, injectee, root);
+            service = mockitoService.findOrCreateSUT(injectee, root);
         } else if (sc != null) {
             service = mockitoService.findOrCreateCollaborator(sc.value(), sc.field(), injectee, root);
         } else if (mc != null) {

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/MC.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/MC.java
@@ -48,7 +48,7 @@ public @interface MC {
      *
      * @return the index of the parameter.
      */
-    int value() default 0;
+    int value() default -1;
 
     /**
      * If the collaborator service being injected is a field of the SUT, this

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
@@ -173,17 +173,22 @@ public class MockitoService {
             return resolve(injectee, root);
         }
 
-        // determine the cache key for the service
-        MockitoCacheKey key;
+        //get the service from the cache.
+        Object service;
 
         if (member instanceof Field) {
-            key = objectFactory.newKey(requiredType, member.getName());
-        } else {
-            key = objectFactory.newKey(requiredType, injectee.getPosition());
-        }
+            MockitoCacheKey key = objectFactory.newKey(requiredType, member.getName());
 
-        //get the service from the cache.
-        Object service = cache.get(key);
+            service = cache.get(key);
+        } else {
+            MockitoCacheKey key = objectFactory.newKey(requiredType, injectee.getPosition());
+            service = cache.get(key);
+
+            if (service == null) {
+                key = objectFactory.newKey(requiredType, -1);
+                service = cache.get(key);
+            }
+        }
 
         //if the service is not found in the cache that means the test class
         //was not injected with services that required mocking or spying.
@@ -218,7 +223,7 @@ public class MockitoService {
 
         //get the service from the cache.
         MockitoCacheKey key;
-        if (member instanceof Field) {
+        if (member instanceof Field && position >= 0) {
             key = objectFactory.newKey(requiredType, position);
         } else {
             key = objectFactory.newKey(requiredType, getFieldName(fieldName, member.getName()));

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
@@ -103,7 +103,7 @@ public class MockitoService {
 
         for (InjectionResolver resolver : resolvers) {
 
-            //ignore mockito inection resolver so we don't get into an infinit loop
+            //ignore mockito injection resolver so we don't get into an infinite loop
             if (resolver instanceof HK2MockitoInjectionResolver) {
                 continue;
             }
@@ -170,8 +170,8 @@ public class MockitoService {
         }
 
         //get the service's parent (the test class) cache. if one is not found 
-        //that means the test class didn't contain any inections that required 
-        //mocking/spying so we return the original sevrice.
+        //that means the test class didn't contain any injections that required
+        //mocking/spying so we return the original service.
         Map<MockitoCacheKey, Object> cache = memberCache.get(serviceParent);
 
         if (cache == null) {
@@ -201,7 +201,7 @@ public class MockitoService {
     }
 
     /**
-     * Given metadata about collborator an an injectee create or resolve the
+     * Given metadata about collaborator and an injectee create or resolve the
      * collaborating service.
      *
      * @param position method or constructor the parameter position metadata

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
@@ -259,8 +259,15 @@ public class MockitoService {
             Class<?> fieldClass = field.getType();
             Type fieldType = field.getGenericType();
 
+            SUT sut = field.getAnnotation(SUT.class);
             SC sc = field.getAnnotation(SC.class);
             MC mc = field.getAnnotation(MC.class);
+
+            if (sut != null || sc != null || mc != null) {
+                // Initialize the parent cache for test fields to make sure
+                // that the order of @SUT and @MC/@SC does not matter.
+                parentCache.put(fieldType, type);
+            }
 
             if (sc != null) {
                 //if we are dealing with spy collaborator then we create an injectee 

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
@@ -57,20 +57,16 @@ public class MockitoService {
     private final ObjectFactory objectFactory;
     private final IterableProvider<InjectionResolver> resolvers;
     private final InjectionResolver<Inject> systemResolver;
-    private final ServiceLocator locator;
-    private Class sut;
 
     @Inject
     MockitoService(MemberCache memberCache,
             ParentCache parentCache,
             ObjectFactory objectFactory,
-            ServiceLocator locator,
             IterableProvider<InjectionResolver> resolvers,
             @Named(SYSTEM_RESOLVER_NAME) InjectionResolver systemResolver) {
         this.memberCache = memberCache;
         this.parentCache = parentCache;
         this.objectFactory = objectFactory;
-        this.locator = locator;
         this.resolvers = resolvers;
         this.systemResolver = systemResolver;
 
@@ -130,7 +126,6 @@ public class MockitoService {
      * @return the service or a proxy spy of the service
      */
     public Object findOrCreateSUT(SUT sut, Injectee injectee, ServiceHandle<?> root) {
-        this.sut = (Class) injectee.getRequiredType();
         Member member = (Member) injectee.getParent();
         Type requiredType = injectee.getRequiredType();
         Type parentType = member.getDeclaringClass();

--- a/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
+++ b/hk2-testing/hk2-mockito/src/main/java/org/jvnet/testing/hk2mockito/internal/MockitoService.java
@@ -226,7 +226,7 @@ public class MockitoService {
         if (member instanceof Field && position >= 0) {
             key = objectFactory.newKey(requiredType, position);
         } else {
-            key = objectFactory.newKey(requiredType, getFieldName(fieldName, member.getName()));
+            key = objectFactory.newKey(requiredType, getOrDefault(fieldName, member.getName()));
         }
 
         return cache.get(key);
@@ -275,7 +275,7 @@ public class MockitoService {
                     //method injection
 
                     MockitoCacheKey executableKey = objectFactory.newKey(fieldType, sc.value());
-                    MockitoCacheKey fieldKey = objectFactory.newKey(fieldType, getFieldName(sc.field(), name));
+                    MockitoCacheKey fieldKey = objectFactory.newKey(fieldType, getOrDefault(sc.field(), name));
 
                     Object spy = objectFactory.newSpy(service);
                     cache.put(executableKey, spy);
@@ -286,25 +286,19 @@ public class MockitoService {
                 //metadata associated with the mock and create a mock of the 
                 //service and add it to the cache twice. one for field injection
                 //and one for method injection.
-                Class<?>[] interfaces = mc.extraInterfaces();
-                String mockName = mc.name();
-
-                if ("".equals(mockName)) {
-                    mockName = name;
-                }
-
                 MockSettings settings = withSettings()
-                        .name(mockName)
+                        .name(getOrDefault(mc.name(), name))
                         .defaultAnswer(mc.answer());
+                Class<?>[] interfaces = mc.extraInterfaces();
 
                 if (interfaces.length > 0) {
-                    settings.extraInterfaces(mc.extraInterfaces());
+                    settings.extraInterfaces(interfaces);
                 }
 
                 Object service = objectFactory.newMock(fieldClass, settings);
 
                 MockitoCacheKey executableKey = objectFactory.newKey(fieldClass, mc.value());
-                MockitoCacheKey fieldKey = objectFactory.newKey(fieldClass, getFieldName(mc.field(), name));
+                MockitoCacheKey fieldKey = objectFactory.newKey(fieldClass, getOrDefault(mc.field(), name));
 
                 cache.put(executableKey, service);
                 cache.put(fieldKey, service);
@@ -333,12 +327,12 @@ public class MockitoService {
         return cache;
     }
 
-    private String getFieldName(String fieldName, String defaultName) {
-        if ("".equals(fieldName)) {
-           return defaultName;
+    private String getOrDefault(String value, String defaultValue) {
+        if ("".equals(value)) {
+           return defaultValue;
         }
         
-        return fieldName;
+        return value;
     }
 
 }

--- a/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/IndirectCollaboratorMockInjectionTest.java
+++ b/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/IndirectCollaboratorMockInjectionTest.java
@@ -16,18 +16,20 @@
 
 package org.jvnet.testing.hk2mockito;
 
-import javax.inject.Inject;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.jvnet.testing.hk2mockito.fixture.BasicGreetingService;
 import org.jvnet.testing.hk2mockito.fixture.service.DeepService;
 import org.jvnet.testing.hk2testng.HK2;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 /**
  * This test implies the ability to build integration tests and mock some of the indirect dependencies.
@@ -37,13 +39,17 @@ import org.testng.annotations.Test;
 @HK2
 public class IndirectCollaboratorMockInjectionTest {
 
-    @SUT
-    @Inject
-    DeepService sut;
-
+    /**
+     * Incidentally this test also helps verify that the order in which the components are declared does not affect the
+     * outcome.
+     */
     @MC
     @Inject
     BasicGreetingService indirectCollaborator;
+
+    @SUT
+    @Inject
+    DeepService sut;
 
     @BeforeClass
     public void verifyInjection() {

--- a/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/IndirectCollaboratorMockInjectionTest.java
+++ b/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/IndirectCollaboratorMockInjectionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.jvnet.testing.hk2mockito;
+
+import javax.inject.Inject;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.jvnet.testing.hk2mockito.fixture.BasicGreetingService;
+import org.jvnet.testing.hk2mockito.fixture.service.DeepService;
+import org.jvnet.testing.hk2testng.HK2;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * This test implies the ability to build integration tests and mock some of the indirect dependencies.
+ *
+ * @author Attila Houtkooper
+ */
+@HK2
+public class IndirectCollaboratorMockInjectionTest {
+
+    @SUT
+    @Inject
+    DeepService sut;
+
+    @MC
+    @Inject
+    BasicGreetingService indirectCollaborator;
+
+    @BeforeClass
+    public void verifyInjection() {
+        assertThat(sut).isNotNull();
+        assertThat(indirectCollaborator).isNotNull();
+        assertThat(mockingDetails(sut).isSpy()).isTrue();
+        assertThat(mockingDetails(indirectCollaborator).isSpy()).isFalse();
+        assertThat(mockingDetails(indirectCollaborator).isMock()).isTrue();
+    }
+
+    @BeforeMethod
+    public void init() {
+        reset(sut, indirectCollaborator);
+    }
+
+    @Test
+    public void callToGreetShouldCallCollboratorGreet() {
+        String greeting = "Hi!";
+        given(indirectCollaborator.greet()).willReturn(greeting);
+
+        String result = sut.greet();
+
+        assertThat(result).isEqualTo(greeting);
+        verify(indirectCollaborator).greet();
+    }
+
+}

--- a/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/MultipleInjectionTest.java
+++ b/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/MultipleInjectionTest.java
@@ -1,0 +1,53 @@
+package org.jvnet.testing.hk2mockito;
+
+import org.jvnet.testing.hk2mockito.fixture.BasicGreetingService;
+import org.jvnet.testing.hk2mockito.fixture.NamedGreetingService;
+import org.jvnet.testing.hk2mockito.fixture.service.MultipleConstructorInjectionService;
+import org.jvnet.testing.hk2testng.HK2;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockingDetails;
+
+/**
+ *
+ * @author Attila Houtkooper
+ */
+@HK2
+public class MultipleInjectionTest {
+
+    @SUT
+    @Inject
+    private MultipleConstructorInjectionService sut;
+
+    @MC
+    @Inject
+    private BasicGreetingService collaborator1;
+
+    @MC
+    @Inject
+    private NamedGreetingService collaborator2;
+
+    @BeforeClass
+    public void verifyInjection() {
+        assertThat(sut).isNotNull();
+        assertThat(collaborator1).isNotNull();
+        assertThat(collaborator2).isNotNull();
+        assertThat(mockingDetails(sut).isMock()).isTrue();
+        assertThat(mockingDetails(sut).isSpy()).isTrue();
+        assertThat(mockingDetails(collaborator1).isMock()).isTrue();
+        assertThat(mockingDetails(collaborator2).isMock()).isTrue();
+        assertThat(mockingDetails(collaborator1).isSpy()).isFalse();
+        assertThat(mockingDetails(collaborator2).isSpy()).isFalse();
+    }
+
+    @Test
+    public void injectedServicesEqualSutProperties() {
+        assertThat(sut.basicGreetingService).isEqualTo(collaborator1);
+        assertThat(sut.namedGreetingService).isEqualTo(collaborator2);
+    }
+
+}

--- a/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/fixture/service/DeepService.java
+++ b/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/fixture/service/DeepService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.jvnet.testing.hk2mockito.fixture.service;
+
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.testing.hk2mockito.fixture.BasicGreetingService;
+
+import javax.inject.Inject;
+
+/**
+ *
+ * @author Attila Houtkooper
+ */
+@Service
+public class DeepService {
+
+    private final ConstructorInjectionGreetingService collaborator;
+
+    @Inject
+    DeepService(ConstructorInjectionGreetingService collaborator) {
+        this.collaborator = collaborator;
+    }
+
+    public String greet() {
+        return collaborator.greet();
+    }
+
+}

--- a/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/fixture/service/MultipleConstructorInjectionService.java
+++ b/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/fixture/service/MultipleConstructorInjectionService.java
@@ -1,0 +1,24 @@
+package org.jvnet.testing.hk2mockito.fixture.service;
+
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.testing.hk2mockito.fixture.BasicGreetingService;
+import org.jvnet.testing.hk2mockito.fixture.NamedGreetingService;
+
+import javax.inject.Inject;
+
+/**
+ *
+ * @author Attila Houtkooper
+ */
+@Service
+public class MultipleConstructorInjectionService {
+
+    public BasicGreetingService basicGreetingService;
+    public NamedGreetingService namedGreetingService;
+
+    @Inject
+    MultipleConstructorInjectionService(BasicGreetingService basicGreetingService, NamedGreetingService namedGreetingService) {
+        this.basicGreetingService = basicGreetingService;
+        this.namedGreetingService = namedGreetingService;
+    }
+}


### PR DESCRIPTION
This PR adds support for testing nested dependencies using `@SUT`, `@MC` and `@SC`.
If Service `A` depends on `B` which in turn depends on `C`. Then this PR allows you to test `A` using `B` while mocking `C`. This is necessary for doing integration testing where a low-level system access service needs to be mocked only.

So now we can declare `@SUT A a` and `@MC C c` which instantiates the intermediate service `B`.

Example:
`org/jvnet/testing/hk2mockito/IndirectCollaboratorMockInjectionTest.java`

At the same time it provides a `JUnitRunner` interface to avoid having to use inheritance. It provides a way to write JUnit tests that conform with the way tests are written in JUnit. It loses the more fine-grained control that comes with inheritance.