### PR TITLE
Fix optional injection bugs

### DIFF
--- a/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceBridgeTestModule.java
+++ b/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceBridgeTestModule.java
@@ -34,6 +34,7 @@ public class GuiceBridgeTestModule implements HK2TestModule {
         config.addActiveDescriptor(HK2Service2Impl.class);
         config.addActiveDescriptor(HK2Service3.class);
         config.addActiveDescriptor(HK2Service4.class);
+        config.addActiveDescriptor(HK2Service5.class);
     }
 
 }

--- a/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceService5.java
+++ b/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceService5.java
@@ -1,0 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.jvnet.hk2.guice.bridge.test;
+
+@FunctionalInterface
+public interface GuiceService5 {
+  public String getName();
+}

--- a/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/HK2Service5.java
+++ b/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/HK2Service5.java
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.jvnet.hk2.guice.bridge.test;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+/** @author Balthasar Schüss */
+public class HK2Service5 {
+  @Inject Optional<GuiceService5> optionalGuiceService;
+}

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/OptionalActiveDescriptor.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/OptionalActiveDescriptor.java
@@ -15,93 +15,78 @@
  */
 package org.jvnet.hk2.internal;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
-import jakarta.inject.Provider;
-import org.glassfish.hk2.api.ActiveDescriptor;
+
 import org.glassfish.hk2.api.DescriptorType;
 import org.glassfish.hk2.api.DescriptorVisibility;
 import org.glassfish.hk2.api.Injectee;
-import org.glassfish.hk2.api.IterableProvider;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceHandle;
-import org.glassfish.hk2.api.messaging.Topic;
 import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
 import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
 
 /**
- * Descriptor for {@link Optional} to allow for injection of a service if it exists or else
- * {@link Optional#EMPTY}.  It will also allow for injection of an {@link Optional} directly as well.
+ * Descriptor for {@link Optional} to allow for injection of a service if it exists or else {@link
+ * Optional#EMPTY}. It will also allow for injection of an {@link Optional} directly as well.
+ *
  * @author jonathan coustick
  */
-public class OptionalActiveDescriptor<T> extends AbstractActiveDescriptor<Optional> {
-    
-    private Injectee injectee;
-    private Type requiredType;
-    private ServiceLocatorImpl locator;
-    
-    /**
-     * For serialization
-     */
-    public OptionalActiveDescriptor() {
-        super();
-    }
-    
-    /*package-private*/ OptionalActiveDescriptor(Injectee injectee, ServiceLocatorImpl locator, Type requiredType) {
-        super(new HashSet<Type>(),
-                PerLookup.class,
-                ReflectionHelper.getNameFromAllQualifiers(injectee.getRequiredQualifiers(), injectee.getParent()),
-                injectee.getRequiredQualifiers(),
-                DescriptorType.CLASS,
-                DescriptorVisibility.NORMAL,
-                0,
-                null,
-                null,
-                locator.getPerLocatorUtilities().getAutoAnalyzerName(injectee.getInjecteeClass()),
-                null);
-        
-        this.requiredType = requiredType;
-        this.injectee = injectee;
-        this.locator = locator;
-    }
+public class OptionalActiveDescriptor<T> extends AbstractActiveDescriptor<Optional<T>> {
 
-    @Override
-    public Class<?> getImplementationClass() {
-        return Optional.class;
-    }
+  private Injectee injectee;
+  private ServiceLocatorImpl locator;
 
-    @Override
-    public Type getImplementationType() {
-        return Optional.class;
-    }
+  /** For serialization */
+  public OptionalActiveDescriptor() {
+    super();
+  }
 
-    @Override
-    public Optional<T> create(ServiceHandle<?> root) {
-        Set<Annotation> qualifierAnnotations = getQualifierAnnotations();
-        Annotation[] annotationsArray = qualifierAnnotations.toArray(new Annotation[qualifierAnnotations.size()]);
+  /*package-private*/ OptionalActiveDescriptor(
+      Injectee injectee,
+      ServiceLocatorImpl locator) {
+    super(
+        new HashSet<Type>(),
+        PerLookup.class,
+        ReflectionHelper.getNameFromAllQualifiers(
+            injectee.getRequiredQualifiers(), injectee.getParent()),
+        injectee.getRequiredQualifiers(),
+        DescriptorType.CLASS,
+        DescriptorVisibility.NORMAL,
+        0,
+        null,
+        null,
+        locator.getPerLocatorUtilities().getAutoAnalyzerName(injectee.getInjecteeClass()),
+        null);
+    this.injectee = injectee;
+    this.locator = locator;
+  }
 
-        ServiceHandle<T> handle = locator.getServiceHandle(requiredType, annotationsArray);
-        if (handle == null) {
-            Class<?> rawType = ReflectionHelper.getRawClass(requiredType);
-            if (Provider.class.equals(rawType) || Iterable.class.equals(rawType) || IterableProvider.class.equals(rawType) || Topic.class.equals(rawType)
-                    || Optional.class.equals(rawType)) {
-                SystemInjecteeImpl copy = new SystemInjecteeImpl(rawType, injectee.getRequiredQualifiers(), injectee.getPosition(),
-                        injectee.getParent(), true, injectee.isSelf(), injectee.getUnqualified(), this);
-                ActiveDescriptor descriptor = locator.getInjecteeDescriptor(copy);
-                return Optional.of((T) descriptor.create(root));
-            }
-            ServiceHandle<Optional<T>> optionalHandle = locator.getServiceHandle(injectee.getRequiredType(), annotationsArray);
-            if (optionalHandle == null) {
-                return Optional.empty();
-            } else {
-                return optionalHandle.getService();
-            }
-        }
-        T service = handle.getService();
-        return Optional.ofNullable(service);
-    }
-    
+  @Override
+  public Class<?> getImplementationClass() {
+    return Optional.class;
+  }
+
+  @Override
+  public Type getImplementationType() {
+    return Optional.class;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Optional<T> create(ServiceHandle<?> root) {
+    Injectee unwrapped =
+        new SystemInjecteeImpl(
+            ReflectionHelper.getFirstTypeArgument(injectee.getRequiredType()),
+            injectee.getRequiredQualifiers(),
+            injectee.getPosition(),
+            injectee.getParent(),
+            true,
+            injectee.isSelf(),
+            injectee.getUnqualified(),
+            this);
+    return Optional.ofNullable(locator.getInjecteeDescriptor(unwrapped))
+        .flatMap(d -> Optional.ofNullable((T) d.create(root)));
+  }
 }

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/OptionalActiveDescriptor.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/OptionalActiveDescriptor.java
@@ -53,8 +53,8 @@ public class OptionalActiveDescriptor<T> extends AbstractActiveDescriptor<Option
     /*package-private*/ OptionalActiveDescriptor(Injectee injectee, ServiceLocatorImpl locator, Type requiredType) {
         super(new HashSet<Type>(),
                 PerLookup.class,
-                null,
-                new HashSet<Annotation>(),
+                ReflectionHelper.getNameFromAllQualifiers(injectee.getRequiredQualifiers(), injectee.getParent()),
+                injectee.getRequiredQualifiers(),
                 DescriptorType.CLASS,
                 DescriptorVisibility.NORMAL,
                 0,

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NamedOptionalInjection.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NamedOptionalInjection.java
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.glassfish.hk2.tests.locator.optional;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+/** @author Balthasar Schüss */
+public class NamedOptionalInjection {
+    @Inject
+    @Named(NamedOptionalTest.NAMED)
+    Optional<String> providedOptional;
+  }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NamedOptionalTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NamedOptionalTest.java
@@ -1,0 +1,130 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package org.glassfish.hk2.tests.locator.optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** @author Balthasar Schüss */
+@RunWith(Parameterized.class)
+public class NamedOptionalTest {
+
+  static final String NAMED = "named";
+  private static final String OTHER_NAMED = "other_named";
+  private static final String UNNAMED = "unnamed";
+
+  @Parameters(
+      name =
+          "otherNamedOptBound={0},otherNamedStrBound={1},unnamedOptBound={2},unnamedStrBound={3}")
+  public static Collection<Object[]> data() {
+    int size = 4;
+    List<Object[]> result = new ArrayList<>();
+    for (int i = 0; i < Math.pow(2, size); i++) {
+      Object[] permutation = new Object[size];
+      for (int j = 1; j <= size; j++) {
+        permutation[j - 1] = i % Math.pow(2, j) - Math.pow(2, j) / 2 >= 0;
+      }
+      result.add(permutation);
+    }
+    return result;
+  }
+
+  private ServiceLocator locator;
+  private boolean otherNamedOptBound;
+  private boolean otherNamedStrBound;
+  private boolean unnamedOptBound;
+  private boolean unnamedStrBound;
+
+  public NamedOptionalTest(
+      boolean otherNamedOptBound,
+      boolean otherNamedStrBound,
+      boolean unnamedOptBound,
+      boolean unnamedStrBound) {
+    this.otherNamedOptBound = otherNamedOptBound;
+    this.otherNamedStrBound = otherNamedStrBound;
+    this.unnamedOptBound = unnamedOptBound;
+    this.unnamedStrBound = unnamedStrBound;
+  }
+
+  @After
+  public void cleanup() {
+    locator.shutdown();
+    locator = null;
+  }
+
+  @Test
+  public void testBoundOptional() {
+    locator = createLocator(true, true);
+    NamedOptionalInjection testObject = locator.getService(NamedOptionalInjection.class);
+    assertTrue(testObject.providedOptional.isPresent());
+    assertEquals(NAMED, testObject.providedOptional.get());
+  }
+
+  @Test
+  public void testNotBoundOptional() {
+    locator = createLocator(true, false);
+    NamedOptionalInjection testObject = locator.getService(NamedOptionalInjection.class);
+    assertFalse(testObject.providedOptional.isPresent());
+  }
+
+  @Test
+  public void testBoundOptionalString() {
+    locator = createLocator(false, true);
+    NamedOptionalInjection testObject = locator.getService(NamedOptionalInjection.class);
+    assertTrue(testObject.providedOptional.isPresent());
+    assertEquals(NAMED, testObject.providedOptional.get());
+  }
+
+  @Test
+  public void testNotBoundOptionalString() {
+    locator = createLocator(false, false);
+    NamedOptionalInjection testObject = locator.getService(NamedOptionalInjection.class);
+    assertFalse(testObject.providedOptional.isPresent());
+  }
+
+  private ServiceLocator createLocator(boolean optional, boolean bound) {
+    ServiceLocator locator = ServiceLocatorFactory.getInstance().create("NamedOptionalTest");
+    ServiceLocatorUtilities.bind(
+        locator,
+        new AbstractBinder() {
+
+          @Override
+          protected void configure() {
+            TypeLiteral<Optional<String>> optType = new TypeLiteral<Optional<String>>() {};
+            if (bound && optional) bind(Optional.of(NAMED)).named(NAMED).to(optType);
+            if (bound && !optional) bind(NAMED).named(NAMED).to(String.class);
+            if (otherNamedOptBound) bind(Optional.of(OTHER_NAMED)).named(OTHER_NAMED).to(optType);
+            if (otherNamedStrBound) bind(OTHER_NAMED).named(OTHER_NAMED).to(String.class);
+            if (unnamedOptBound) bind(Optional.of(UNNAMED)).to(optType);
+            if (unnamedStrBound) bind(UNNAMED).to(String.class);
+            bindAsContract(NamedOptionalInjection.class);
+          }
+        });
+    return locator;
+  }
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NestedOptionalInjection.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NestedOptionalInjection.java
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.glassfish.hk2.tests.locator.optional;
+
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+/** @author Balthasar Schüss */
+public class NestedOptionalInjection {
+
+  @Inject Optional<Optional<String>> providedOptional;
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NestedOptionalTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NestedOptionalTest.java
@@ -1,0 +1,141 @@
+/********************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.glassfish.hk2.tests.locator.optional;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.testng.Assert;
+
+/** @author Balthasar Schüss */
+public class NestedOptionalTest {
+
+  private  class TestBinder extends AbstractBinder {
+
+    private final Consumer<AbstractBinder> configure;
+
+    public TestBinder(Consumer<AbstractBinder> configure) {
+      this.configure = configure;
+    }
+
+    @Override
+    protected void configure() {
+      bindAsContract(NestedOptionalInjection.class);
+      configure.accept(TestBinder.this);
+    }
+  }
+
+  private ServiceLocator locator;
+
+  @Before
+  public void setup() {
+    locator = ServiceLocatorFactory.getInstance().create("NestedOptionalTest");
+  }
+
+  @After
+  public void cleanup() {
+    locator.shutdown();
+    locator = null;
+  }
+
+  private void configure(Consumer<AbstractBinder> configure) {
+    ServiceLocatorUtilities.bind(locator, new TestBinder(configure));
+  }
+
+  @Test
+  public void testNotBound() {
+    configure(binder -> {});
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertFalse(service.providedOptional.get().isPresent());
+  }
+
+  @Test
+  public void testBoundFully() {
+    configure(
+        binder -> {
+          binder
+              .bind(Optional.of(Optional.of("test0")))
+              .to(new TypeLiteral<Optional<Optional<String>>>() {});
+        });
+
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertTrue(service.providedOptional.get().isPresent());
+    Assert.assertTrue(service.providedOptional.get().get().equals("test0"));
+  }
+
+  @Test
+  public void testBoundPartially() {
+    configure(
+        binder -> binder.bind(Optional.of("test0")).to(new TypeLiteral<Optional<String>>() {}));
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertTrue(service.providedOptional.get().isPresent());
+    Assert.assertTrue(service.providedOptional.get().get().equals("test0"));
+  }
+
+  @Test
+  public void testBoundPartiallyEmpty() {
+    configure(binder -> binder.bind(Optional.empty()).to(new TypeLiteral<Optional<String>>() {}));
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertFalse(service.providedOptional.get().isPresent());
+  }
+
+  @Test
+  public void testBoundAtomically() {
+    configure(binder -> binder.bind("test0").to(String.class));
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertTrue(service.providedOptional.get().isPresent());
+    Assert.assertTrue(service.providedOptional.get().get().equals("test0"));
+  }
+
+  @Test
+  public void testSpecifityPrecedenceFullyBeforeAll() {
+	configure(binder -> {
+		binder.bind(Optional.of(Optional.of("fully"))).to(new TypeLiteral<Optional<Optional<String>>>() {});
+		binder.bind(Optional.of("partial")).to(new TypeLiteral<Optional<String>>() {});
+		binder.bind("atomic").to(String.class);
+	});
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertTrue(service.providedOptional.get().isPresent());
+    Assert.assertTrue(service.providedOptional.get().get().equals("fully"));
+  }
+
+  @Test
+  public void testSpecifityPrecedencePartialBeforeAtmoic() {
+	configure(binder -> {
+		binder.bind(Optional.of("partial")).to(new TypeLiteral<Optional<String>>() {});
+		binder.bind("atomic").to(new TypeLiteral<Optional<String>>() {});
+	});
+    NestedOptionalInjection service = locator.getService(NestedOptionalInjection.class);
+    Assert.assertTrue(service.providedOptional.isPresent());
+    Assert.assertTrue(service.providedOptional.get() instanceof Optional);
+    Assert.assertTrue(service.providedOptional.get().isPresent());
+    Assert.assertTrue(service.providedOptional.get().get().equals("partial"));
+  }
+}


### PR DESCRIPTION
Add tests and fixes for:
1. OptionalActiveDescriptor fails to inject @Named optional values, because (name) qualifiers are not propagated for the retrieval of the wrapped value. As a consequence any bound instance (unnamed, with same name, or other name) may be injected.
This is a treacherous bug, in particular when injecting configuration parameters and migrating from previous versions.
2. Trying to inject Optional<Optional<String>> one might expect the following:
    - Binding a literal string results to Optional<Optional<String>>, but actaally Optional<Optional.empty> is injected
    - Binding Optional<Optional<String> results to Optional<Optional<String>, but actually Optional<Optional<Optional<String>>> is injected    
    Furthermore, one might expect that more specific bindings take precedence over less specific bindings, that is also not the case.
    It is true that nested Optionals are not a common use case, but the precedence should be implemented either way.

3. Trying to inject Guice services as Optional into hk2 services always causes the optional to be empty.

