### PR TITLE
Downgrade javaassist to 3.22.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <glassfish.jakarta.el.version>4.0.0</glassfish.jakarta.el.version>
         <jakarta.el.version>4.0.0</jakarta.el.version>
         <jtype.version>0.1.3</jtype.version>
-        <javassist.version>3.27.0-GA</javassist.version>
+        <javassist.version>3.22.0-GA</javassist.version>
         <junit.version>4.13.1</junit.version>
         <asm.version>7.3.1</asm.version>
         <woodstox.version>4.1.2</woodstox.version>


### PR DESCRIPTION
Sorry for this.. I had locally tested with 3.22.0-GA but updated it to 3.27.0-GA in the previous PR #539 