### PR TITLE
Build jdk15

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Changes since 3.0.1
+
+* Support for JDK15
+
 Changes since 2.6.1
 * Convert package usage from javax to jakarta
 * Improvements to annotation parser, including support for generics and enums

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -168,5 +168,28 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                          <groupId>org.apache.maven.plugins</groupId>
+                          <artifactId>maven-surefire-plugin</artifactId>
+                          <executions>
+                                <execution>
+                                    <id>default-testCompile</id>
+                                </execution>
+                          </executions>
+                          <configuration>
+                              <argLine>--illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                          </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2019, 2020 Payara Services Ltd.
+    Copyright (c) 2019, 2021 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -169,7 +169,7 @@
             </build>
         </profile>
         <profile>
-            <id>jdk9+</id>
+            <id>jdk9plus</id>
             <activation>
                 <jdk>[9,)</jdk>
                 <activeByDefault>false</activeByDefault>

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2019, 2021 Payara Services Ltd.
+    Copyright (c) 2019, 2020 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -164,29 +164,6 @@
                                     </configuration>
                                 </execution>
                           </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk9plus</id>
-            <activation>
-                <jdk>[9,)</jdk>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
-                          <artifactId>maven-surefire-plugin</artifactId>
-                          <executions>
-                                <execution>
-                                    <id>default-testCompile</id>
-                                </execution>
-                          </executions>
-                          <configuration>
-                              <argLine>--illegal-access=permit --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                          </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/hk2-locator/src/test/resources/policy.txt
+++ b/hk2-locator/src/test/resources/policy.txt
@@ -1,4 +1,4 @@
-//Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+//Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 //
 //This program and the accompanying materials are made available under the
 //terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,6 +85,8 @@ grant codeBase "file:${build.dir}/classes/-" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "setContextClassLoader";
   permission java.lang.RuntimePermission "createClassLoader";
+  permission java.lang.RuntimePermission "createSecurityManager";
+  permission java.lang.RuntimePermission "defineClass";  
   permission java.util.PropertyPermission "javassist.*", "read";
   permission java.util.PropertyPermission "org.jvnet.*", "read";
   permission java.lang.RuntimePermission "getProtectionDomain";

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <glassfish.jakarta.el.version>4.0.0</glassfish.jakarta.el.version>
         <jakarta.el.version>4.0.0</jakarta.el.version>
         <jtype.version>0.1.3</jtype.version>
-        <javassist.version>3.22.0-GA</javassist.version>
+        <javassist.version>3.27.0-GA</javassist.version>
         <junit.version>4.13.1</junit.version>
         <asm.version>7.3.1</asm.version>
         <woodstox.version>4.1.2</woodstox.version>


### PR DESCRIPTION
Continuation of PR #542

Revert hk2-locator/pom.xml to original
Resolve AccessControlException thrown with javassist-3.27.0-GA
```
java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "createSecurityManager")
java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "defineClass")
```
These exceptions are visible only when passing the -Djava.security.debug=access flag.