### PR TITLE
Changes to pass the DI TCK

### DIFF
--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2020, 2021 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -1419,6 +1419,9 @@ public class Utilities {
                                 " is static, abstract or has a parameter that is an annotation"));
                 continue;
             }
+            if (Modifier.isStatic(method.getModifiers())) {
+                continue;
+            }
 
             retVal.add(method);
         }
@@ -1485,6 +1488,9 @@ public class Utilities {
                         Pretty.field(field) + " may not be static, final or have an Annotation type"));
                 continue;
             }
+            if (Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
 
             retVal.add(field);
         }
@@ -1518,7 +1524,7 @@ public class Utilities {
     }
 
   private static boolean isProperMethod(Method member) {
-        if (ReflectionHelper.isStatic(member)) return false;
+        //if (ReflectionHelper.isStatic(member)) return false;
         if (isAbstract(member)) return false;
         for (Class<?> paramClazz : member.getParameterTypes()) {
             if (paramClazz.isAnnotation()) {
@@ -1530,7 +1536,7 @@ public class Utilities {
     }
 
     private static boolean isProperField(Field field) {
-        if (ReflectionHelper.isStatic(field)) return false;
+        //if (ReflectionHelper.isStatic(field)) return false;
         if (isFinal(field)) return false;
         Class<?> type = field.getType();
         return !type.isAnnotation();

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/field/NegativeFieldTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/field/NegativeFieldTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,14 +37,10 @@ public class NegativeFieldTest {
      */
     @Test
     public void testStaticField() {
-        try {
             locator.reifyDescriptor(locator.getBestDescriptor(BuilderHelper.createContractFilter(
                     StaticFieldService.class.getName())));
-            Assert.fail("static field should cause failure");
-        }
-        catch (MultiException me) {
-            Assert.assertTrue(me.getMessage().contains(" may not be static, final or have an Annotation type"));
-        }
+            StaticFieldService fieldService = locator.getService(StaticFieldService.class);
+            Assert.assertNull(fieldService.locator);
     }
     
     /**

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/field/StaticFieldService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/field/StaticFieldService.java
@@ -27,6 +27,6 @@ import org.glassfish.hk2.api.ServiceLocator;
  */
 public class StaticFieldService {
     @Inject
-    static ServiceLocator locator;
+    public static ServiceLocator locator;
 
 }

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/method/NegativeMethodTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/method/NegativeMethodTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 package org.glassfish.hk2.tests.locator.negative.method;
 
+import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
@@ -37,12 +39,14 @@ public class NegativeMethodTest {
     @Test
     public void testStaticMethod() {
         try {
-            locator.reifyDescriptor(locator.getBestDescriptor(BuilderHelper.createContractFilter(
+            ActiveDescriptor descriptor = locator.reifyDescriptor(locator.getBestDescriptor(BuilderHelper.createContractFilter(
                     StaticMethodService.class.getName())));
-            Assert.fail("static method should cause failure");
+            StaticMethodService methodService = locator.getService(StaticMethodService.class);
         }
         catch (MultiException me) {
-            Assert.assertTrue(me.getMessage().contains("is static, abstract or has a parameter that is an annotation"));
+            me.printStackTrace();
+            Assert.fail(me.getMessage());
+           // Assert.assertTrue(me.getMessage(), me.getMessage().contains("is static, abstract or has a parameter that is an annotation"));
         }
     }
     

--- a/hk2-testing/di-tck/pom.xml
+++ b/hk2-testing/di-tck/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Payara Services Ltd. and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-testing</artifactId>
+        <version>3.0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hk2-di-tck-runner</artifactId>
+    <name>DI TCK Runner</name>
+    <description>Runner for the Jakarta DI TCK</description>
+    
+    <properties>
+        <ditck.version>2.0.1</ditck.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>jakarta.inject</groupId>
+                            <artifactId>jakarta.inject-api</artifactId>
+                            <version>2.0.0</version>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>jakarta.inject</groupId>
+                            <artifactId>jakarta.inject-tck</artifactId>
+                            <version>${ditck.version}</version>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                        </artifactItem>
+                    </artifactItems>
+                    <overWriteReleases>false</overWriteReleases>
+                    <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <includes>
+                        <include>${runSuite}</include>
+                    </includes>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-tck</artifactId>
+            <version>${ditck.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-locator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/hk2-testing/di-tck/src/test/java/org/glassfish/hk2/ditck/TCKRunner.java
+++ b/hk2-testing/di-tck/src/test/java/org/glassfish/hk2/ditck/TCKRunner.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Payara Services Ltd. and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.hk2.ditck;
+
+import jakarta.inject.Singleton;
+import org.atinject.tck.Tck;
+import org.atinject.tck.auto.*;
+import org.atinject.tck.auto.accessories.*;
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+
+/**
+ * Runner for the DI TCK
+ * @author Jonathan Coustick
+ */
+public class TCKRunner {
+
+    public static junit.framework.Test suite() {
+
+        ServiceLocator locator = ServiceLocatorUtilities.createAndPopulateServiceLocator("test-locator");
+        DynamicConfiguration dynamicConfig = ServiceLocatorUtilities.createDynamicConfiguration(locator);
+        
+        dynamicConfig.bind(BuilderHelper.link(FuelTank.class).build());
+        dynamicConfig.bind(BuilderHelper.link(Seat.class).in(Singleton.class).build());
+        dynamicConfig.bind(BuilderHelper.link(DriversSeat.class).to(Seat.class).qualifiedBy(Drivers.class.getName()).build());
+        dynamicConfig.bind(BuilderHelper.link(Seatbelt.class).build());
+        dynamicConfig.bind(BuilderHelper.link(V8Engine.class).to(GasEngine.class).to(Engine.class).build());
+        dynamicConfig.bind(BuilderHelper.link(Cupholder.class).in(Singleton.class).build());
+        dynamicConfig.bind(BuilderHelper.link(Tire.class).build());
+        dynamicConfig.bind(BuilderHelper.link(SpareTire.class).to(Tire.class).named("spare").build());
+        dynamicConfig.bind(BuilderHelper.link(Convertible.class).to(Car.class).build());
+        
+        dynamicConfig.commit();
+        Car tckCar = locator.getService(Car.class);
+        return Tck.testsFor(tckCar, false, true);
+    }
+
+}

--- a/hk2-testing/pom.xml
+++ b/hk2-testing/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,6 +39,7 @@
         <module>hk2-runlevel-extras</module>
         <module>hk2-locator-no-proxies</module>
         <module>hk2-locator-no-proxies2</module>
+        <module>di-tck</module>
         <module>interceptor-events</module>
         <module>hk2-mockito</module>
         <module>collections</module>

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/reflection/internal/ClassReflectionHelperUtilities.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/reflection/internal/ClassReflectionHelperUtilities.java
@@ -148,6 +148,11 @@ public class ClassReflectionHelperUtilities {
         return retVal;
     }
     
+    /**
+     * Returns methods of a class, including those in superclasses and interfaces.
+     * @param clazz Class to get methods of
+     * @return 
+     */
     static Set<MethodWrapper> getAllMethodWrappers(Class<?> clazz) {
         if (clazz == null) return Collections.emptySet();
         if (Object.class.equals(clazz)) return OBJECT_METHODS;

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/reflection/internal/MethodWrapperImpl.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/reflection/internal/MethodWrapperImpl.java
@@ -17,6 +17,7 @@
 package org.glassfish.hk2.utilities.reflection.internal;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 import org.glassfish.hk2.utilities.reflection.MethodWrapper;
 import org.glassfish.hk2.utilities.reflection.Pretty;
@@ -42,11 +43,21 @@ public class MethodWrapperImpl implements MethodWrapper {
         
         hashCode ^= method.getName().hashCode();
         hashCode ^= method.getReturnType().hashCode();
+        int modifiers = method.getModifiers();
+        if (Modifier.isPrivate(modifiers)) {
+           hashCode ^= method.getDeclaringClass().hashCode();
+        } else if (isPackagePrivate(modifiers)) {
+           hashCode ^= method.getDeclaringClass().getPackage().hashCode();
+        }
         for (Class<?> param : method.getParameterTypes()) {
             hashCode ^= param.hashCode();
         }
         
         this.hashCode = hashCode;
+    }
+    
+    private boolean isPackagePrivate(int modifiers) {
+        return !Modifier.isPublic(modifiers) && !Modifier.isProtected(modifiers) && !Modifier.isPrivate(modifiers);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This changes HK2 injection order to match that required by TCK.
It also changes behaviour when encountering static injection to ignore it rather than throwing an error as that prevents the TCK from running.

Requires https://github.com/eclipse-ee4j/injection-tck/pull/15 to be merged, which adds a qualifier that the TCK requires.