### PR TITLE
Fixed Jenkinsfile - empty volumeMounts removed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,6 @@ spec:
   - name: jnlp
     image: jenkins/jnlp-slave:alpine
     imagePullPolicy: IfNotPresent
-    volumeMounts:
     env:
       - name: JAVA_TOOL_OPTIONS
         value: -Xmx1G


### PR DESCRIPTION
- causes that Jenkins stays waiting for an executor forever