### PR TITLE
Upgraded version ASM opsCodes from 7 to 9 

### DIFF
--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractAnnotationVisitorImpl.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractAnnotationVisitorImpl.java
@@ -30,7 +30,7 @@ public abstract class AbstractAnnotationVisitorImpl extends AnnotationVisitor {
      * Gives the version implemented to the superclass
      */
     public AbstractAnnotationVisitorImpl() {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
     }
     
     /* (non-Javadoc)

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractClassVisitorImpl.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractClassVisitorImpl.java
@@ -32,7 +32,7 @@ public abstract class AbstractClassVisitorImpl extends ClassVisitor {
      * The constructor that gives the version we are implementing to the superclass
      */
     public AbstractClassVisitorImpl() {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
     }
 
     /* (non-Javadoc)

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractMethodVisitorImpl.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractMethodVisitorImpl.java
@@ -33,7 +33,7 @@ public abstract class AbstractMethodVisitorImpl extends MethodVisitor {
      * The constructor that gives the implemented version to the superclass
      */
     public AbstractMethodVisitorImpl() {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
For proper JDK-17 support there is a need to have ASM9 support otherwise PermittedSubclasses requires ASM9 appears. Please consider this PR to be applied to master. 