### PR TITLE
Remove unused imports

### DIFF
--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotationTypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotationTypeImpl.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.classmodel.reflect.impl;
 
 import org.glassfish.hk2.classmodel.reflect.*;
-import org.glassfish.hk2.classmodel.reflect.util.ParsingConfig;
 
 import java.util.*;
 

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/InterfaceModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/InterfaceModelImpl.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.classmodel.reflect.impl;
 
 import org.glassfish.hk2.classmodel.reflect.*;
-import org.glassfish.hk2.classmodel.reflect.util.ParsingConfig;
 
 import java.util.*;
 

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ModelBuilder.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ModelBuilder.java
@@ -16,10 +16,7 @@
 
 package org.glassfish.hk2.classmodel.reflect.impl;
 
-import org.glassfish.hk2.classmodel.reflect.*;
-import org.objectweb.asm.Opcodes;
 import java.net.URI;
-import java.util.Collection;
 
 /**
  * convenient class to build model implementations

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.classmodel.reflect.impl;
 
-import org.glassfish.hk2.classmodel.reflect.InterfaceModel;
 import org.glassfish.hk2.classmodel.reflect.ParameterizedInterfaceModel;
 
 import java.util.*;

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.classmodel.reflect.impl;
 
 import org.glassfish.hk2.classmodel.reflect.*;
-import org.glassfish.hk2.classmodel.reflect.util.ParsingConfig;
 import org.objectweb.asm.Opcodes;
 
 import java.net.URI;

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/util/DirectoryArchive.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/util/DirectoryArchive.java
@@ -21,7 +21,6 @@ import org.glassfish.hk2.classmodel.reflect.Parser;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.net.URI;
-import java.nio.channels.FileChannel;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Level;

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ordering/JarTest.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ordering/JarTest.java
@@ -19,14 +19,9 @@ package org.glassfish.hk2.classmodel.reflect.test.ordering;
 import org.glassfish.hk2.classmodel.reflect.Parser;
 import org.glassfish.hk2.classmodel.reflect.ParsingContext;
 import org.glassfish.hk2.classmodel.reflect.Type;
-import org.glassfish.hk2.classmodel.reflect.util.InputStreamArchiveAdapter;
 import org.junit.Ignore;
 
 import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/guice-bridge/src/main/java/org/jvnet/hk2/guice/bridge/internal/GuiceIntoHK2BridgeImpl.java
+++ b/guice-bridge/src/main/java/org/jvnet/hk2/guice/bridge/internal/GuiceIntoHK2BridgeImpl.java
@@ -18,8 +18,6 @@ package org.jvnet.hk2.guice.bridge.internal;
 
 import jakarta.inject.Inject;
 
-import org.glassfish.hk2.api.DynamicConfiguration;
-import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.jvnet.hk2.annotations.Service;

--- a/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceBridgeModule.java
+++ b/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceBridgeModule.java
@@ -20,12 +20,6 @@ package org.jvnet.hk2.guice.bridge.test;
 import org.glassfish.hk2.utilities.NamedImpl;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.internal.Annotations;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.util.List;
-import jakarta.inject.Qualifier;
-import java.util.ArrayList;
 import org.jvnet.hk2.guice.bridge.api.GuiceBridge;
 
 /**

--- a/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceService2.java
+++ b/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/GuiceService2.java
@@ -16,8 +16,6 @@
 
 package org.jvnet.hk2.guice.bridge.test;
 
-import jakarta.inject.Inject;
-
 import org.junit.Assert;
 import org.jvnet.hk2.guice.bridge.api.HK2Inject;
 

--- a/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/bidirectional/BiDirectionalBridgeModule.java
+++ b/guice-bridge/src/test/java/org/jvnet/hk2/guice/bridge/test/bidirectional/BiDirectionalBridgeModule.java
@@ -17,8 +17,6 @@
 package org.jvnet.hk2.guice.bridge.test.bidirectional;
 
 import org.glassfish.hk2.api.DynamicConfiguration;
-import org.jvnet.hk2.guice.bridge.internal.GuiceIntoHK2BridgeImpl;
-import org.jvnet.hk2.guice.bridge.internal.GuiceScopeContext;
 import org.jvnet.hk2.testing.junit.HK2TestModule;
 
 /**

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/ServiceHandle.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/ServiceHandle.java
@@ -17,11 +17,7 @@
 package org.glassfish.hk2.api;
 
 import java.io.Closeable;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This service handle can be used to get a specific instance

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/BuilderHelper.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/BuilderHelper.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.utilities;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/ClasspathDescriptorFileFinder.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/ClasspathDescriptorFileFinder.java
@@ -16,14 +16,10 @@
 
 package org.glassfish.hk2.utilities;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;

--- a/hk2-api/src/test/java/org/glassfish/hk2/tests/contracts/RequestProcessor.java
+++ b/hk2-api/src/test/java/org/glassfish/hk2/tests/contracts/RequestProcessor.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.hk2.tests.contracts;
 
-import org.jvnet.hk2.annotations.Contract;
-
 /**
  *
  */

--- a/hk2-api/src/test/java/org/glassfish/hk2/tests/contracts/RouteBuilder.java
+++ b/hk2-api/src/test/java/org/glassfish/hk2/tests/contracts/RouteBuilder.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.hk2.tests.contracts;
 
-import org.jvnet.hk2.annotations.Contract;
-
 /**
  * Created by IntelliJ IDEA.
  * User: dochez

--- a/hk2-api/src/test/java/org/glassfish/hk2/utilities/binding/Fantastic.java
+++ b/hk2-api/src/test/java/org/glassfish/hk2/utilities/binding/Fantastic.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.utilities.binding;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/hk2-configuration/hk2-integration/src/test/java/org/glassfish/hk2/configuration/tests/threaded/ConfiguredService.java
+++ b/hk2-configuration/hk2-integration/src/test/java/org/glassfish/hk2/configuration/tests/threaded/ConfiguredService.java
@@ -18,10 +18,8 @@ package org.glassfish.hk2.configuration.tests.threaded;
 
 import java.util.List;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
-import org.glassfish.hk2.api.IterableProvider;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.configuration.api.Configured;
 import org.glassfish.hk2.configuration.api.ConfiguredBy;

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBUtilities.java
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBUtilities.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.pbuf.internal;
 
-import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,8 +24,6 @@ import org.glassfish.hk2.pbuf.api.annotations.OneOf;
 import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
 import org.glassfish.hk2.utilities.reflection.MethodWrapper;
 import org.glassfish.hk2.utilities.reflection.internal.ClassReflectionHelperImpl;
-
-import com.google.protobuf.CodedInputStream;
 
 /**
  * @author jwells

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBufGeneratorProcessor.java
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBufGeneratorProcessor.java
@@ -60,8 +60,6 @@ import org.glassfish.hk2.utilities.general.GeneralUtilities;
 import org.glassfish.hk2.xml.internal.Generator;
 import org.glassfish.hk2.xml.internal.Utilities;
 
-import com.google.protobuf.Method;
-
 /**
  * @author jwells
  *

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/test/java/org/glassfish/hk2/pbuf/test/basic/PBufParserTest.java
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/test/java/org/glassfish/hk2/pbuf/test/basic/PBufParserTest.java
@@ -18,7 +18,6 @@ package org.glassfish.hk2.pbuf.test.basic;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/test/java/org/glassfish/hk2/pbuf/test/beans/OneOfRootBean.java
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/test/java/org/glassfish/hk2/pbuf/test/beans/OneOfRootBean.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.hk2.pbuf.test.beans;
 
-import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/AdapterInformationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/AdapterInformationImpl.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.hk2.xml.internal;
 
-import jakarta.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.glassfish.hk2.xml.internal.alt.AdapterInformation;
 import org.glassfish.hk2.xml.internal.alt.AltClass;
 

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.xml.internal;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;

--- a/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/beans/JMSServerBean.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/beans/JMSServerBean.java
@@ -18,7 +18,6 @@ package org.glassfish.hk2.xml.test.beans;
 
 import java.util.List;
 
-import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlIDREF;
 

--- a/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/childlocators/ChildLocatorTest.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/childlocators/ChildLocatorTest.java
@@ -23,7 +23,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.configuration.hub.api.Hub;
 import org.glassfish.hk2.xml.api.XmlRootHandle;
 import org.glassfish.hk2.xml.api.XmlService;
-import org.glassfish.hk2.xml.spi.XmlServiceParser;
 import org.glassfish.hk2.xml.test.beans.DomainBean;
 import org.glassfish.hk2.xml.test.dynamic.merge.MergeTest;
 import org.glassfish.hk2.xml.test.utilities.Utilities;

--- a/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/defaulting/DefaultingTest.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/defaulting/DefaultingTest.java
@@ -16,23 +16,11 @@
 
 package org.glassfish.hk2.xml.test.defaulting;
 
-import java.net.URL;
-
-import javax.xml.namespace.QName;
-
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.hk2.configuration.hub.api.Hub;
-import org.glassfish.hk2.xml.api.XmlHk2ConfigurationBean;
-import org.glassfish.hk2.xml.api.XmlRootHandle;
 import org.glassfish.hk2.xml.api.XmlService;
 import org.glassfish.hk2.xml.spi.XmlServiceParser;
-import org.glassfish.hk2.xml.test.beans.DomainBean;
-import org.glassfish.hk2.xml.test.beans.SSLManagerBean;
 import org.glassfish.hk2.xml.test.beans.SSLManagerBeanCustomizer;
-import org.glassfish.hk2.xml.test.beans.SecurityManagerBean;
-import org.glassfish.hk2.xml.test.dynamic.merge.MergeTest;
 import org.glassfish.hk2.xml.test.utilities.Utilities;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**

--- a/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/dynamic/marshall/MarshallTest.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/dynamic/marshall/MarshallTest.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.xml.test.dynamic.marshall;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/dynamic/overlay/OverlayTest.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/dynamic/overlay/OverlayTest.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.xml.test.dynamic.overlay;
 
 import java.net.URL;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import org.glassfish.hk2.configuration.hub.api.Change;
 import org.glassfish.hk2.configuration.hub.api.Hub;
 import org.glassfish.hk2.configuration.hub.api.Instance;
 import org.glassfish.hk2.configuration.hub.api.Change.ChangeCategory;
-import org.glassfish.hk2.configuration.hub.api.Type;
 import org.glassfish.hk2.xml.api.XmlHk2ConfigurationBean;
 import org.glassfish.hk2.xml.api.XmlRootHandle;
 import org.glassfish.hk2.xml.api.XmlService;

--- a/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/negative/api/NegativeAPITest.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/test/negative/api/NegativeAPITest.java
@@ -25,7 +25,6 @@ import java.net.URL;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 
-import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Filter;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.BuilderHelper;

--- a/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/Annotation.java
+++ b/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/Annotation.java
@@ -24,7 +24,6 @@
 
 package org.glassfish.hk2.xml.schema.beans;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.xml.bind.annotation.XmlAccessType;

--- a/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/Redefine.java
+++ b/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/Redefine.java
@@ -24,7 +24,6 @@
 
 package org.glassfish.hk2.xml.schema.beans;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.xml.bind.annotation.XmlAccessType;

--- a/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/SimpleType.java
+++ b/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/SimpleType.java
@@ -24,8 +24,6 @@
 
 package org.glassfish.hk2.xml.schema.beans;
 
-import java.util.ArrayList;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;

--- a/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/Union.java
+++ b/hk2-configuration/persistence/hk2-xml/schema/src/main/java/org/glassfish/hk2/xml/schema/beans/Union.java
@@ -24,7 +24,6 @@
 
 package org.glassfish.hk2.xml.schema.beans;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.xml.bind.annotation.XmlAccessType;

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileHandle.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileHandle.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.configuration.persistence.properties;
 
-import java.io.IOException;
 import java.util.Properties;
 
 /**

--- a/hk2-core/src/main/java/com/sun/enterprise/module/bootstrap/Main.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/bootstrap/Main.java
@@ -31,8 +31,6 @@ import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.api.PopulatorPostProcessor;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.glassfish.hk2.utilities.Binder;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.common_impl.AbstractFactory;

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractFactory.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractFactory.java
@@ -18,7 +18,6 @@ package com.sun.enterprise.module.common_impl;
 
 import com.sun.enterprise.module.ModuleDefinition;
 import com.sun.enterprise.module.ModulesRegistry;
-import com.sun.enterprise.module.HK2Module;
 
 /**
  * @author Sanjeeb.Sahoo@Sun.COM

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/ByteArrayInhabitantsDescriptor.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/ByteArrayInhabitantsDescriptor.java
@@ -17,7 +17,6 @@
 package com.sun.enterprise.module.common_impl;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URL;

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/Jar.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/Jar.java
@@ -20,15 +20,10 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URL;
-import java.util.Enumeration;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
-import java.util.logging.Level;
 import java.util.zip.ZipException;
 
-import com.sun.enterprise.module.InhabitantsDescriptor;
 import com.sun.enterprise.module.ModuleMetadata;
 
 /**

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/CookedModuleDefinition.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/CookedModuleDefinition.java
@@ -18,14 +18,12 @@ package com.sun.enterprise.module.impl;
 
 import com.sun.enterprise.module.ModuleDependency;
 import com.sun.enterprise.module.common_impl.DefaultModuleDefinition;
-import com.sun.enterprise.module.common_impl.DefaultModuleDefinition;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 import java.net.URI;
 
 /**

--- a/hk2-core/src/main/java/org/glassfish/hk2/bootstrap/HK2Populator.java
+++ b/hk2-core/src/main/java/org/glassfish/hk2/bootstrap/HK2Populator.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.bootstrap;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 

--- a/hk2-extras/src/test/java/org/glassfish/hk2/tests/locator/messaging/operation/EventReceivingFactory.java
+++ b/hk2-extras/src/test/java/org/glassfish/hk2/tests/locator/messaging/operation/EventReceivingFactory.java
@@ -18,11 +18,9 @@ package org.glassfish.hk2.tests.locator.messaging.operation;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.annotation.PreDestroy;

--- a/hk2-extras/src/test/java/org/glassfish/hk2/tests/operation/basic/Frobnicator.java
+++ b/hk2-extras/src/test/java/org/glassfish/hk2/tests/operation/basic/Frobnicator.java
@@ -19,11 +19,9 @@ package org.glassfish.hk2.tests.operation.basic;
 import jakarta.inject.Inject;
 
 import org.glassfish.hk2.api.ProxyCtl;
-import org.glassfish.hk2.api.ServiceLocator;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @BasicOperationScope
 public class Frobnicator {

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ClazzCreator.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ClazzCreator.java
@@ -20,7 +20,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/alias/AliasDescriptorTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/alias/AliasDescriptorTest.java
@@ -25,7 +25,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.utilities.AliasDescriptor;
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.glassfish.hk2.utilities.NamedImpl;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.junit.Assert;
 import org.junit.Test;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/arrays/ArraysModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/arrays/ArraysModule.java
@@ -16,20 +16,15 @@
 
 package org.glassfish.hk2.tests.locator.arrays;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
 import jakarta.inject.Singleton;
 
-import org.glassfish.hk2.api.Descriptor;
 import org.glassfish.hk2.api.DynamicConfiguration;
-import org.glassfish.hk2.api.FactoryDescriptors;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.tests.locator.utilities.TestModule;
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.jvnet.hk2.internal.Utilities;
 
 /**
  * @author jwells

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/classanalysis/ClassAnalysisModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/classanalysis/ClassAnalysisModule.java
@@ -23,7 +23,6 @@ import org.glassfish.hk2.api.DynamicConfiguration;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.tests.locator.utilities.TestModule;
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 
 /**
  * @author jwells

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/classanalysis/JaxRsClassAnalyzer.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/classanalysis/JaxRsClassAnalyzer.java
@@ -29,8 +29,6 @@ import jakarta.inject.Singleton;
 
 import org.glassfish.hk2.api.ClassAnalyzer;
 import org.glassfish.hk2.api.MultiException;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-import org.glassfish.hk2.utilities.reflection.Logger;
 
 /**
  * Implementation of the ClassAnalyzer that prefers the

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/context/ghost/ContextGhostTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/context/ghost/ContextGhostTest.java
@@ -18,12 +18,10 @@ package org.glassfish.hk2.tests.locator.context.ghost;
 
 import java.lang.annotation.Annotation;
 
-import jakarta.inject.Singleton;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.AnnotationLiteral;
 import org.glassfish.hk2.api.Descriptor;
-import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.BuilderHelper;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/descriptornamed/DescriptorNamedTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/descriptornamed/DescriptorNamedTest.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.tests.locator.descriptornamed;
 
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.hk2.tests.locator.customresolver.CustomResolverModule;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.junit.Assert;
 import org.junit.Test;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/immediate/ImmediateTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/immediate/ImmediateTest.java
@@ -32,7 +32,6 @@ import org.glassfish.hk2.api.FactoryDescriptors;
 import org.glassfish.hk2.api.Immediate;
 import org.glassfish.hk2.api.ImmediateController;
 import org.glassfish.hk2.api.ImmediateController.ImmediateServiceState;
-import org.glassfish.hk2.api.ServiceHandle;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.BuilderHelper;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/justintime/EvilJITResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/justintime/EvilJITResolver.java
@@ -18,13 +18,10 @@ package org.glassfish.hk2.tests.locator.justintime;
 
 import java.lang.reflect.Type;
 
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import org.glassfish.hk2.api.Injectee;
 import org.glassfish.hk2.api.JustInTimeInjectionResolver;
-
-import org.glassfish.hk2.utilities.BuilderHelper;
 
 @Singleton
 public class EvilJITResolver implements JustInTimeInjectionResolver {

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/locator/LocatorTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/locator/LocatorTest.java
@@ -37,7 +37,6 @@ import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.glassfish.hk2.utilities.DescriptorImpl;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.junit.Assert;
 import org.junit.Ignore;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/locatorutilities/ParameterizedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/locatorutilities/ParameterizedService.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.hk2.tests.locator.locatorutilities;
 
-import jakarta.inject.Singleton;
-
 import org.jvnet.hk2.annotations.Contract;
 
 /**

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/deadlock1/Deadlock1Test.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/negative/deadlock1/Deadlock1Test.java
@@ -25,7 +25,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/parented/ParentedModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/parented/ParentedModule.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.hk2.tests.locator.parented;
 
-import jakarta.inject.Singleton;
-
 import org.glassfish.hk2.api.DynamicConfiguration;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.tests.locator.utilities.TestModule;

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/parented/ServiceWithParentContextInjectionPoint.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/parented/ServiceWithParentContextInjectionPoint.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.tests.locator.parented;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.glassfish.hk2.api.PerLookup;
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/perlookup/ThriceInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/perlookup/ThriceInjectedService.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.tests.locator.perlookup;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import org.glassfish.hk2.api.PerLookup;
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/provider/ProviderInjected.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/provider/ProviderInjected.java
@@ -18,7 +18,6 @@ package org.glassfish.hk2.tests.locator.provider;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
-import jakarta.inject.Singleton;
 
 /**
  * @author jwells

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/qualifiers/ImplementationQualifier.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/qualifiers/ImplementationQualifier.java
@@ -16,9 +16,6 @@
 
 package org.glassfish.hk2.tests.locator.qualifiers;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/qualifiers/QualifierTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/qualifiers/QualifierTest.java
@@ -25,7 +25,6 @@ import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceHandle;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/shutdown/ShutdownTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/shutdown/ShutdownTest.java
@@ -20,7 +20,6 @@ import org.junit.Assert;
 
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorState;
-import org.glassfish.hk2.tests.locator.qualifiers.QualifierModule;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.junit.Test;
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/visibility/VisibilityTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/visibility/VisibilityTest.java
@@ -19,7 +19,6 @@ package org.glassfish.hk2.tests.locator.visibility;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/async/CancelTest.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/async/CancelTest.java
@@ -31,7 +31,6 @@ import org.glassfish.hk2.runlevel.RunLevelController;
 import org.glassfish.hk2.runlevel.RunLevelFuture;
 import org.glassfish.hk2.runlevel.tests.utilities.Utilities;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hk2.annotations.Service;
 

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/cancel/BlockingPreDestroyService2.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/cancel/BlockingPreDestroyService2.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.hk2.runlevel.tests.cancel;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/cancel/CancelTest.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/cancel/CancelTest.java
@@ -26,7 +26,6 @@ import org.glassfish.hk2.runlevel.RunLevelController.ThreadingPolicy;
 import org.glassfish.hk2.runlevel.RunLevelFuture;
 import org.glassfish.hk2.runlevel.tests.utilities.Utilities;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/failmeagain/FailMeAgainTest.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/failmeagain/FailMeAgainTest.java
@@ -21,7 +21,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.runlevel.RunLevelController;
 import org.glassfish.hk2.runlevel.tests.utilities.Utilities;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener1/UpListener.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener1/UpListener.java
@@ -16,10 +16,8 @@
 
 package org.glassfish.hk2.runlevel.tests.listener1;
 
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
-import org.glassfish.hk2.api.IterableProvider;
 import org.glassfish.hk2.runlevel.ChangeableRunLevelFuture;
 import org.glassfish.hk2.runlevel.ErrorInformation;
 import org.glassfish.hk2.runlevel.ProgressStartedListener;

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/sync/ThreadSensitiveService.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/sync/ThreadSensitiveService.java
@@ -17,7 +17,6 @@
 package org.glassfish.hk2.runlevel.tests.sync;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.glassfish.hk2.runlevel.RunLevel;

--- a/hk2-testing/di-tck/src/test/java/org/glassfish/hk2/ditck/TCKRunner.java
+++ b/hk2-testing/di-tck/src/test/java/org/glassfish/hk2/ditck/TCKRunner.java
@@ -16,7 +16,6 @@
 package org.glassfish.hk2.ditck;
 
 import jakarta.inject.Singleton;
-import java.lang.annotation.Annotation;
 import org.atinject.tck.Tck;
 import org.atinject.tck.auto.*;
 import org.atinject.tck.auto.accessories.*;

--- a/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/ServiceLocatorTestRule.java
+++ b/hk2-testing/hk2-junitrunner/src/main/java/org/jvnet/hk2/testing/junit/ServiceLocatorTestRule.java
@@ -26,10 +26,6 @@ import java.io.InputStreamReader;
 import java.io.PrintStream; // for javadoc only
 
 import java.lang.annotation.Annotation;
-import java.lang.annotation.Documented;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 
 import java.lang.reflect.AnnotatedElement;
 
@@ -51,7 +47,6 @@ import java.util.zip.ZipFile;
 
 import jakarta.inject.Singleton;
 
-import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Descriptor;
 import org.glassfish.hk2.api.DynamicConfiguration;
 import org.glassfish.hk2.api.DynamicConfigurationService;
@@ -63,8 +58,6 @@ import org.glassfish.hk2.api.ServiceLocatorState;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Opcodes;
 
 import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
 import org.glassfish.hk2.utilities.Binder;
@@ -73,7 +66,6 @@ import org.glassfish.hk2.utilities.DescriptorImpl;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 
 import org.junit.ClassRule; // for javadoc only
-import org.junit.Test;
 
 import org.junit.rules.ExternalResource;
 
@@ -91,7 +83,6 @@ import org.jvnet.hk2.testing.junit.internal.ClassVisitorImpl;
 import org.jvnet.hk2.testing.junit.internal.ErrorServiceImpl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
 /**

--- a/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleTest.java
+++ b/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleTest.java
@@ -17,16 +17,11 @@
 package org.jvnet.hk2.testing.test;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 
 import org.glassfish.hk2.api.ServiceLocator;
 
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-
 import org.junit.Rule;
 import org.junit.Test;
-
-import org.junit.rules.TestRule;
 
 import org.junit.runner.Description;
 

--- a/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleWithClassesTest.java
+++ b/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleWithClassesTest.java
@@ -17,25 +17,17 @@
 package org.jvnet.hk2.testing.test;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 
 import org.glassfish.hk2.api.ServiceLocator;
 
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-
 import org.junit.Rule;
 import org.junit.Test;
-
-import org.junit.rules.TestRule;
-
-import org.junit.runner.Description;
 
 import org.jvnet.hk2.testing.junit.ServiceLocatorTestRule;
 import org.jvnet.hk2.testing.junit.ServiceLocatorTestRule.ServiceLocatorIsolation;
 
 import org.jvnet.hk2.testing.junit.annotations.Classes;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @Classes({

--- a/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleWithInhabitantFilesTest.java
+++ b/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleWithInhabitantFilesTest.java
@@ -17,25 +17,17 @@
 package org.jvnet.hk2.testing.test;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 
 import org.glassfish.hk2.api.ServiceLocator;
 
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-
 import org.junit.Rule;
 import org.junit.Test;
-
-import org.junit.rules.TestRule;
-
-import org.junit.runner.Description;
 
 import org.jvnet.hk2.testing.junit.ServiceLocatorTestRule;
 import org.jvnet.hk2.testing.junit.ServiceLocatorTestRule.ServiceLocatorIsolation;
 
 import org.jvnet.hk2.testing.junit.annotations.InhabitantFiles;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @InhabitantFiles({

--- a/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleWithPackagesTest.java
+++ b/hk2-testing/hk2-junitrunner/src/test/java/org/jvnet/hk2/testing/test/ServiceLocatorTestRuleWithPackagesTest.java
@@ -17,19 +17,13 @@
 package org.jvnet.hk2.testing.test;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 
 import org.glassfish.hk2.api.ServiceLocator;
 
 import org.glassfish.hk2.utilities.BuilderHelper;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 
 import org.junit.Rule;
 import org.junit.Test;
-
-import org.junit.rules.TestRule;
-
-import org.junit.runner.Description;
 
 import org.jvnet.hk2.testing.junit.ServiceLocatorTestRule;
 import org.jvnet.hk2.testing.junit.ServiceLocatorTestRule.ServiceLocatorIsolation;
@@ -38,7 +32,6 @@ import org.jvnet.hk2.testing.junit.annotations.Packages;
 
 import org.jvnet.hk2.testing.test.alt.AnotherAltService;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 

--- a/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/fixture/service/DeepService.java
+++ b/hk2-testing/hk2-mockito/src/test/java/org/jvnet/testing/hk2mockito/fixture/service/DeepService.java
@@ -17,7 +17,6 @@
 package org.jvnet.testing.hk2mockito.fixture.service;
 
 import org.jvnet.hk2.annotations.Service;
-import org.jvnet.testing.hk2mockito.fixture.BasicGreetingService;
 
 import jakarta.inject.Inject;
 

--- a/hk2-testing/interceptor-events/src/test/java/org/glassfish/hk2/aopEvents/test/AOPEventsTest.java
+++ b/hk2-testing/interceptor-events/src/test/java/org/glassfish/hk2/aopEvents/test/AOPEventsTest.java
@@ -26,7 +26,6 @@ import org.glassfish.hk2.aopEvents.PackageEventSubscriberService;
 import org.glassfish.hk2.aopEvents.PrivateEventSubscriberService;
 import org.glassfish.hk2.aopEvents.ProtectedEventSubscriberService;
 import org.glassfish.hk2.extras.ExtrasUtilities;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/reflection/GenericArrayTypeImpl.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/reflection/GenericArrayTypeImpl.java
@@ -18,7 +18,6 @@ package org.glassfish.hk2.utilities.reflection;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 
 import org.glassfish.hk2.utilities.general.GeneralUtilities;
 

--- a/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/HK2Main.java
+++ b/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/HK2Main.java
@@ -32,7 +32,6 @@ import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.PopulatorPostProcessor;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
-import org.glassfish.hk2.utilities.Binder;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;

--- a/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/OSGiObrModulesRegistryImpl.java
+++ b/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/OSGiObrModulesRegistryImpl.java
@@ -18,7 +18,6 @@
 package org.jvnet.hk2.osgiadapter;
 
 import com.sun.enterprise.module.*;
-import com.sun.enterprise.module.Repository;
 import org.osgi.framework.*;
 
 import java.net.URI;

--- a/spring-bridge/src/test/java/org/jvnet/hk2/spring/bridge/test/hk2tospring/HK2ToSpringTest.java
+++ b/spring-bridge/src/test/java/org/jvnet/hk2/spring/bridge/test/hk2tospring/HK2ToSpringTest.java
@@ -18,13 +18,10 @@ package org.jvnet.hk2.spring.bridge.test.hk2tospring;
 
 import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.jvnet.hk2.spring.bridge.api.SpringScopeImpl;
 import org.jvnet.hk2.spring.bridge.test.utilities.LocatorAndContext;
 import org.jvnet.hk2.spring.bridge.test.utilities.Utilities;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * @author jwells


### PR DESCRIPTION
I was looking for usages of certain classes in this project and found some false positives because of unused imports so I cleaned them up in the entire project.

There were 6 classes that I did not remove the unused imports from. Example: [Auditable](https://github.com/eclipse-ee4j/glassfish-hk2/blob/master/hk2-configuration/persistence/hk2-xml/main/src/test/java/org/glassfish/hk2/xml/lifecycle/config/Auditable.java#L19-L22) has unused imports but are referenced by code that is commented out so I left those.