### PR TITLE
Revert "Bump mockito-core from 2.18.3 to 4.4.0"

### DIFF
--- a/hk2-testing/hk2-mockito/pom.xml
+++ b/hk2-testing/hk2-mockito/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.4.0</version>
+            <version>2.18.3</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Reverts eclipse-ee4j/glassfish-hk2#588

Breaks the code. Mockito needs to be updated manually.