### PR TITLE
Bump assertj-core from 3.15.0 to 3.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <stax-api.version>1.0-2</stax-api.version>
         <aopalliance.version>1.0</aopalliance.version>
         <testng.version>7.1.0</testng.version>
-        <assertj.version>3.15.0</assertj.version>
+        <assertj.version>3.22.0</assertj.version>
         <pax-exam-version>4.13.1</pax-exam-version>
         <jakarta-inject.version>2.0.0</jakarta-inject.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Insane.

Original PR
- #604 

consistently fails on Jenkins. In test that seems to not use AssertJ.
Cannot reproduce that fail locally.

I've checked every AJ version in https://ci.eclipse.org/glassfish/job/hk2/job/pr604/ - and not a single one failed.
This PR - identical with PR-604: https://github.com/eclipse-ee4j/glassfish-hk2/compare/dependabot/maven/org.assertj-assertj-core-3.22.0..pzygielo:assertj passed Jenkins fine.

I've no clues for the reason.

-----

This closes #604.