### PR TITLE
Un-mix TestNG Assert from JUnit Tests

### DIFF
--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/children/ChildServiceLocatorTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/children/ChildServiceLocatorTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Payara Services Ltd.
  * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +22,7 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorState;
 import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
 import org.junit.Test;
-import org.testng.Assert;
+import org.junit.Assert;
 
 /**
  *

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NestedOptionalTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/optional/NestedOptionalTest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.testng.Assert;
+import org.junit.Assert;
 
 /** @author Balthasar Schüss */
 public class NestedOptionalTest {


### PR DESCRIPTION
This will (partially) help with
- #607 

There is a 3.5 release of EasyMock (currently used here) that has TestNG classes included (it's fixed in [3.5.1](https://github.com/easymock/easymock/releases/tag/easymock-3.5.1)), that polluted CP.
HK2 has no TestNG on CP, hence the problem of upgrading from 3.5 up.