### PR TITLE
Explicit version for m-install-p

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,10 @@
                     <artifactId>depends-maven-plugin</artifactId>
                     <version>1.4.0</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Avoid
```
21:55:58  [WARNING] 
21:55:58  [WARNING] Some problems were encountered while building the effective model for org.glassfish.hk2:hk2-di-tck-runner:jar:3.0.4-SNAPSHOT
21:55:58  [WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-install-plugin is missing. @ line 93, column 21
21:55:58  [WARNING] 
21:55:58  [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
21:55:58  [WARNING] 
21:55:58  [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
21:55:58  [WARNING] 
```
from modules explicitly using that plugin w/o version.

2.4 is the version configured in current maven.