### PR TITLE
Extend timeout to 120s

### DIFF
--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/multithreaded1/MultiThreaded1Test.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/multithreaded1/MultiThreaded1Test.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -104,7 +105,7 @@ public class MultiThreaded1Test {
         }
         
         for (int lcv = 0; lcv < NUM_THREADS; lcv++) {
-            runners[lcv].isDone(20 * 1000);
+            runners[lcv].isDone(120 * 1000);
         }
         
     }
@@ -133,7 +134,7 @@ public class MultiThreaded1Test {
         }
         
         for (int lcv = 0; lcv < NUM_THREADS; lcv++) {
-            runners[lcv].isDone(60 * 1000);
+            runners[lcv].isDone(120 * 1000);
         }
         
     }


### PR DESCRIPTION
It seems this test depends on performance of machine it runs on:
- https://ci.eclipse.org/glassfish/job/hk2/job/PR-643/1/console
- https://ci.eclipse.org/glassfish/job/hk2/job/master/86/console
- https://ci.eclipse.org/glassfish/job/hk2/job/master/89/console
- https://ci.eclipse.org/glassfish/job/hk2/job/master/91/console

Thus I propose to patch it with new timeout value for now.