### PR TITLE
Drop management of unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,6 @@
         <assertj.version>3.23.1</assertj.version>
         <pax-exam-version>4.13.1</pax-exam-version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
-        <slf4j.version>1.7.36</slf4j.version>
         <org.jboss.logging.version>3.5.0.Final</org.jboss.logging.version>
         <jersey.version>3.1.0-M6</jersey.version>
         <grizzly.version>4.0.0</grizzly.version>
@@ -696,11 +695,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.framework</artifactId>
                 <version>7.0.5</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Related:
- https://github.com/eclipse-ee4j/glassfish-hk2/pull/714
- https://github.com/eclipse-ee4j/glassfish-hk2/pull/597

It seems initial contribution had this only managed. Upstream used this dependency in `:osgi-adapter-test`, but it was later removed from that module.
`slf4j-simple` does not transit from other dependencies:
```
[INFO] --- maven-dependency-plugin:3.3.0:tree (default-cli) @ osgi-adapter-test ---
[INFO] org.glassfish.hk2:osgi-adapter-test:jar:3.0.4-SNAPSHOT
[INFO] +- org.glassfish.hk2:hk2-utils:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2:hk2-api:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2:hk2-locator:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2:hk2-runlevel:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2:hk2-core:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.javassist:javassist:jar:3.29.1-GA:compile
[INFO] +- org.glassfish.hk2:test-module-startup:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2:contract-bundle:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2:no-hk2-bundle:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.hibernate.validator:hibernate-validator:jar:7.0.5.Final:compile
[INFO] |  +- jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.5.0.Final:compile
[INFO] |  \- com.fasterxml:classmate:jar:1.5.1:compile
[INFO] +- org.glassfish.hk2:sdp-management-bundle:jar:3.0.4-SNAPSHOT:compile
[INFO] +- org.glassfish.hk2.external:aopalliance-repackaged:jar:3.0.4-SNAPSHOT:compile
[INFO] +- jakarta.inject:jakarta.inject-api:jar:2.0.1:compile
[INFO] +- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
[INFO] +- jakarta.el:jakarta.el-api:jar:5.0.1:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-container-native:jar:4.13.1:compile
[INFO] |  +- org.ops4j.pax.exam:pax-exam:jar:4.13.1:compile
[INFO] |  |  +- org.ops4j.base:ops4j-base-store:jar:1.5.0:compile
[INFO] |  |  \- org.ops4j.base:ops4j-base-util-property:jar:1.5.0:compile
[INFO] |  +- org.ops4j.pax.exam:pax-exam-spi:jar:4.13.1:compile
[INFO] |  |  +- org.ops4j.base:ops4j-base-spi:jar:1.5.0:compile
[INFO] |  |  \- org.ops4j.pax.tinybundles:tinybundles:jar:2.1.1:compile
[INFO] |  |     \- biz.aQute.bnd:bndlib:jar:2.4.0:compile
[INFO] |  +- org.ops4j.pax.swissbox:pax-swissbox-core:jar:1.8.2:compile
[INFO] |  |  \- org.ops4j.pax.swissbox:pax-swissbox-lifecycle:jar:1.8.2:compile
[INFO] |  +- org.ops4j.pax.swissbox:pax-swissbox-tracker:jar:1.8.2:compile
[INFO] |  +- org.ops4j.base:ops4j-base-lang:jar:1.5.0:compile
[INFO] |  +- org.ops4j.base:ops4j-base-net:jar:1.5.0:compile
[INFO] |  |  \- org.ops4j.base:ops4j-base-monitors:jar:1.5.0:compile
[INFO] |  +- org.ops4j.pax.url:pax-url-link:jar:2.4.5:compile
[INFO] |  |  \- org.ops4j.pax.url:pax-url-commons:jar:2.4.5:compile
[INFO] |  |     \- org.ops4j.pax.swissbox:pax-swissbox-property:jar:1.8.2:compile
[INFO] |  \- org.ops4j.pax.url:pax-url-classpath:jar:2.4.5:compile
[INFO] |     \- org.ops4j.pax.swissbox:pax-swissbox-optional-jcl:jar:1.8.2:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-junit4:jar:4.13.1:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-link-mvn:jar:4.13.1:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-inject:jar:4.13.1:compile
[INFO] |  \- org.ops4j.pax.swissbox:pax-swissbox-framework:jar:1.8.2:compile
[INFO] |     +- org.ops4j.base:ops4j-base-exec:jar:1.5.0:compile
[INFO] |     \- org.ops4j.base:ops4j-base-io:jar:1.5.0:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-invoker-junit:jar:4.13.1:compile
[INFO] +- org.ops4j.pax.logging:pax-logging-api:jar:1.11.2:compile
[INFO] |  +- org.osgi:osgi.core:jar:8.0.0:compile
[INFO] |  \- org.osgi:osgi.cmpn:jar:7.0.0:compile
[INFO] +- org.ops4j.pax.exam:pax-exam-extender-service:jar:4.13.1:compile
[INFO] |  \- org.ops4j.pax.swissbox:pax-swissbox-extender:jar:1.8.2:compile
[INFO] +- org.ops4j.pax.url:pax-url-aether:jar:2.6.1:compile
[INFO] |  +- org.ops4j.pax.url:pax-url-aether-support:jar:2.6.1:compile
[INFO] |  |  \- org.apache.maven.resolver:maven-resolver-impl:jar:1.3.1:compile
[INFO] |  |     +- org.apache.maven.resolver:maven-resolver-api:jar:1.3.1:compile
[INFO] |  |     +- org.apache.maven.resolver:maven-resolver-spi:jar:1.3.1:compile
[INFO] |  |     \- org.apache.maven.resolver:maven-resolver-util:jar:1.3.1:compile
[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.6.6:compile
[INFO] +- org.apache.felix:org.apache.felix.framework:jar:7.0.5:compile
[INFO] |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.9:compile
[INFO] +- org.apache.felix:org.apache.felix.configadmin:jar:1.9.24:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.2.11:compile
[INFO] +- ch.qos.logback:logback-classic:jar:1.2.11:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.32:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] \- org.easymock:easymock:jar:4.3:test
[INFO]    \- org.objenesis:objenesis:jar:3.2:test
```