### PR TITLE
FISH-6432 Applications Take Longer To Deploy on JDK 17

### DIFF
--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,14 +48,6 @@ public class TypeImpl extends AnnotatedElementImpl implements Type {
 
     synchronized void addDefiningURI(URI uri) {
         definingURIs.add(uri);
-        try {
-            File file = new File(uri);
-//            assert(file.exists()) : file + " does not exist";
-            definingURIs.add(file.getCanonicalFile().toURI());
-        } catch (IOException e) {
-            // ignore, this is a safeguard for confused user's code that do not
-            // deal well with file path.
-        }
     }
 
     @Override

--- a/hk2-api/src/main/java/org/glassfish/hk2/internal/PerThreadContext.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/internal/PerThreadContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +18,7 @@
 package org.glassfish.hk2.internal;
 
 import java.lang.annotation.Annotation;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
@@ -117,10 +119,14 @@ public class PerThreadContext implements Context<PerThread> {
     }
     
     private static class PerContextThreadWrapper {
-        private final HashMap<ActiveDescriptor<?>, Object> instances =
-                new HashMap<ActiveDescriptor<?>, Object>();
+
+        private final HashMap<ActiveDescriptor<?>, Object> instances = new HashMap<>();
         private final long id = Thread.currentThread().getId();
-        
+
+        public PerContextThreadWrapper() {
+            registerStopEvent();
+        }
+                
         public boolean has(ActiveDescriptor<?> d) {
             return instances.containsKey(d);
         }
@@ -133,13 +139,14 @@ public class PerThreadContext implements Context<PerThread> {
             instances.put(d, v);
         }
         
-        @Override
-        public void finalize() throws Throwable {
-            instances.clear();
-            
-            if (LOG_THREAD_DESTRUCTION) {
-                Logger.getLogger().debug("Removing PerThreadContext data for thread " + id);
-            }
+        public final void registerStopEvent() {
+            CleanerFactory.create().register(this, () -> {
+                instances.clear();
+
+                if (LOG_THREAD_DESTRUCTION) {
+                    Logger.getLogger().debug("Removing PerThreadContext data for thread " + id);
+                }
+            });
         }
         
     }

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/CleanerFactory.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/CleanerFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.hk2.utilities;
+
+import java.lang.ref.Cleaner;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * CleanerFactory provides a Cleaner reference which is created on the first
+ * reference to the CleanerFactory.
+ */
+public final class CleanerFactory {
+
+    /* The common Cleaner. */
+    private final static Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
+        @Override
+        public Thread newThread(final Runnable r) {
+            return AccessController.doPrivileged(new PrivilegedAction<>() {
+                @Override
+                public Thread run() {
+                    Thread t = new Thread(null, r, "Common-Cleaner");
+                    t.setPriority(Thread.MAX_PRIORITY - 2);
+                    return t;
+                }
+            });
+        }
+    });
+
+
+    /**
+     * This Cleaner will run on a thread whose context class loader
+     * is {@code null}. The system cleaning action to perform in
+     * this Cleaner should handle a {@code null} context class loader.
+     *
+     * @return a common cleaner reference
+     */
+    public static Cleaner create() {
+        return commonCleaner;
+    }
+}

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderFacade.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderFacade.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,11 +21,13 @@ import com.sun.enterprise.module.common_impl.LogHelper;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import org.glassfish.hk2.utilities.CleanerFactory;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.ArrayList;
+import java.util.logging.Level;
 
 /**
  * Facade for {@link ModuleClassLoader} to only expose public classes.
@@ -43,12 +46,14 @@ final class ClassLoaderFacade extends URLClassLoader {
     public ClassLoaderFacade(ModuleClassLoader privateLoader) {
         super(EMPTY_URLS, privateLoader.getParent());
         this.privateLoader = privateLoader;
+        registerStopEvent();
     }
 
-    protected void finalize() throws Throwable {
-        super.finalize();
-        LogHelper.getDefaultLogger().fine("Facade ClassLoader killed " + privateLoader.getOwner().getModuleDefinition().getName());
-        privateLoader.stop();
+    public final void registerStopEvent() {
+        CleanerFactory.create().register(this, () -> {
+            LogHelper.getDefaultLogger().log(Level.FINE, "Facade ClassLoader killed {0}", privateLoader.getOwner().getModuleDefinition().getName());
+            privateLoader.stop();
+        });
     }
 
     public void setPublicPkgs(String[] publicPkgs) {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +24,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.io.IOException;
+import org.glassfish.hk2.utilities.CleanerFactory;
 
 /**
  * ClassLoaderProxy capable of loading classes from itself but also from other class loaders
@@ -37,11 +39,7 @@ public class ClassLoaderProxy extends URLClassLoader {
     /** Creates a new instance of ClassLoader */
     public ClassLoaderProxy(URL[] shared, ClassLoader parent) {
         super(shared, parent);
-    }
-
-    protected void finalize() throws Throwable {
-        super.finalize();
-        stop();
+        registerStopEvent();
     }
 
     protected Class<?> loadClass(String name, boolean resolve, boolean followImports)
@@ -193,7 +191,7 @@ public class ClassLoaderProxy extends URLClassLoader {
     }
 
     public Collection<ClassLoader> getDelegates() {
-        return new ArrayList<ClassLoader>(surrogates);
+        return new ArrayList<>(surrogates);
     }
 
 
@@ -201,11 +199,18 @@ public class ClassLoaderProxy extends URLClassLoader {
      * called by the facade class loader when it is garbage collected.
      * this is a good time to see if this module should be unloaded.
      */
-    public void stop() {
-       surrogates.clear();
-       facadeSurrogates.clear();
+    public final void registerStopEvent() {
+        CleanerFactory.create().register(this, () -> {
+            stop();
+        });
     }
 
+    public void stop() {
+        surrogates.clear();
+        facadeSurrogates.clear();
+    }
+
+    @Override
     public String toString() {
         StringBuffer s= new StringBuffer();
         s.append(",URls[]=");

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,12 +50,6 @@ final class ModuleClassLoader extends ClassLoaderProxy {
         super(shared, parent);
         this.module = owner;
     }
-    
-    protected void finalize() throws Throwable {
-        super.finalize();
-        LogHelper.getDefaultLogger().info("ModuleClassLoader gc'ed " + module.getModuleDefinition().getName());
-    }
-
 
     protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         initialize(name);


### PR DESCRIPTION
In this PR, a few performance optimizations have been done.
- The `finalize` method has been deprecated and removed from FileInputStream, FileOutputStream, Zip Inflator, and  Deflator in JDK 12 which may cause resources are not cleaned and leak.
- File canonicalization cache is disabled by default in JDK 12 which helps in performance optimizations for file name canonicalization. In TypeImpl#addDefiningURI duplicate uri is added so canonicalization is not required.