### PR TITLE
Fix bundle manifest generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,12 +259,13 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <!-- By default, we don't export anything. -->
-                    <Export-Package />
                     <instructions>
+                        <Export-Package />
                         <!-- Read all the configuration from osgi.bundle file, if it exists.
                              See Felix-699 to find out why we use ${basedir}.
                         -->
                         <_include>-${basedir}/osgi.bundle</_include>
+                        <_noimportjava>true</_noimportjava>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Avoid import of `java.*` packages into bundle manifest.

Signed-off-by: Alexander Pinčuk <alexander.v.pinchuk@gmail.com>