### PR TITLE
Using compatible arguments

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
---activate-profiles staging
+-Pstaging
+


### PR DESCRIPTION
Fixes 

```
mvn clean install
Unable to parse maven.config file options: Unrecognized option: --activate-profiles staging
```

with Maven 3.9.0+