### PR TITLE
Fixed issues reported by maven when we tried to deploy a pre-release

### DIFF
--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -31,7 +31,7 @@
     <description>A utility for running HK2 tests</description>
 
     <properties>
-        <links>http://junit.org/javadoc/latest/</links>
+        <links>https://junit.org/junit4/javadoc/latest/</links>
     </properties>
 
     <build>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <maven.site.skip>true</maven.site.skip>    
+        <maven.site.skip>true</maven.site.skip>
         <manifest.location></manifest.location> <!-- to make nullifiy the property -->
     </properties>
 
@@ -53,9 +53,6 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/staging/apidocs</outputDirectory>
-                            <additionalOptions>
-                                <additionalOption>${javadoc.options}</additionalOption>
-                            </additionalOptions>
                             <sourcepath>
                                 ${basedir}/../hk2-api/src/main/java;
                                 ${basedir}/../hk2-locator/src/main/java;

--- a/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
+++ b/maven-plugins/consolidatedbundle-maven-plugin/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>maven-plugin-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-osgi</artifactId>
         </dependency>

--- a/maven-plugins/consolidatedbundle-maven-plugin/src/main/java/com/sun/enterprise/module/maven/HK2GenerateMojo.java
+++ b/maven-plugins/consolidatedbundle-maven-plugin/src/main/java/com/sun/enterprise/module/maven/HK2GenerateMojo.java
@@ -17,11 +17,6 @@
 
 package com.sun.enterprise.module.maven;
 
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.artifact.Artifact;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -30,6 +25,11 @@ import java.io.OutputStream;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Generates a consolidated OSGI bundle with a consolidated HK2 header
@@ -53,21 +53,21 @@ public class HK2GenerateMojo extends AbstractMojo {
     /**
      * Directory where the manifest will be written
      *
-     * @parameter expression="${manifestLocation}"
-     * default-value="${project.build.outputDirectory}"
+     * @parameter property="manifestLocation" default-value="${project.build.outputDirectory}"
      */
     protected File manifestLocation;
     /**
      * The maven project.
      *
-     * @parameter expression="${project}"
+     * @parameter property="project"
      * @required
      * @readonly
      */
     protected MavenProject project;
 
-    @SuppressWarnings("unchecked")
+    @Override
     public void execute() throws MojoExecutionException {
+        @SuppressWarnings("unchecked")
         Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
         if (dependencyArtifacts == null) {
             return;

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -53,6 +53,9 @@
                  <executions>
                      <execution>
                          <id>gendir</id>
+                         <goals>
+                             <goal>testCompile</goal>
+                         </goals>
                          <configuration>
                              <testExcludes>
                                  <exclude>**/negative/*</exclude>
@@ -60,12 +63,12 @@
                              </testExcludes>
                              <outputDirectory>${project.build.testOutputDirectory}/gendir</outputDirectory>
                          </configuration>
-                         <goals>
-                             <goal>testCompile</goal>
-                         </goals>
                      </execution>
                      <execution>
                          <id>negative</id>
+                         <goals>
+                             <goal>testCompile</goal>
+                         </goals>
                          <configuration>
                              <testExcludes>
                                  <exclude>generator</exclude>
@@ -75,9 +78,6 @@
                              </testIncludes>
                              <outputDirectory>${project.build.testOutputDirectory}/negative</outputDirectory>
                          </configuration>
-                         <goals>
-                             <goal>testCompile</goal>
-                         </goals>
                      </execution>
                  </executions>
              </plugin>
@@ -86,7 +86,7 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <executions>
                      <execution>
-                         <id>>gendir-package</id>
+                         <id>gendir-package</id>
                          <goals>
                              <goal>test-jar</goal>
                          </goals>
@@ -126,17 +126,14 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>${asm.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-tree</artifactId>
-            <version>${asm.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-util</artifactId>
-            <version>${asm.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
@@ -157,6 +154,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${mvn.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -146,14 +146,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${mvn.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/AbstractInhabitantsGeneratorMojo.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/AbstractInhabitantsGeneratorMojo.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,49 +35,49 @@ import org.jvnet.hk2.generator.HabitatGenerator;
  */
 public abstract class AbstractInhabitantsGeneratorMojo extends AbstractMojo {
     private final static String WAR_PACKAGING = "war";
-    
+
     private final static String WEB_INF = "WEB-INF";
     private final static String CLASSES = "classes";
-    
+
     /**
-     * @parameter expression="${project.build.directory}"
+     * @parameter property="project.build.directory"
      */
     private File targetDirectory;
-    
+
     /**
      * The maven project.
      *
-     * @parameter expression="${project}" @required @readonly
+     * @parameter property="project" @required @readonly
      */
     protected MavenProject project;
-    
+
     /**
      * @parameter
      */
     private boolean verbose;
-    
+
     /**
      * @parameter default-value=true
      */
-    private boolean includeDate = true;
-    
+    private final boolean includeDate = true;
+
     /**
      * @parameter
      */
     private String locator;
-    
+
     /**
-     * @parameter expression="${supportedProjectTypes}" default-value="jar,ejb,war"
+     * @parameter property="supportedProjectTypes" default-value="jar,ejb,war"
      */
     private String supportedProjectTypes;
-    
+
     protected abstract boolean getNoSwap();
     protected abstract File getOutputDirectory();
-    
+
     protected boolean isWar() {
        return WAR_PACKAGING.equals(project.getPackaging());
     }
-    
+
     /**
      * This method will compile the inhabitants file based on
      * the classes just compiled
@@ -91,7 +92,7 @@ public abstract class AbstractInhabitantsGeneratorMojo extends AbstractMojo {
             }
             return;
         }
-        
+
         if (!getOutputDirectory().exists()) {
             if (!getOutputDirectory().mkdirs()) {
                 getLog().info("Could not create output directory " +
@@ -99,81 +100,81 @@ public abstract class AbstractInhabitantsGeneratorMojo extends AbstractMojo {
                 return;
             }
         }
-        
+
         if (!getOutputDirectory().exists()) {
             getLog().info("Exiting hk2-inhabitant-generator because could not find output directory " +
                   getOutputDirectory().getAbsolutePath());
             return;
         }
-        
+
         if (verbose) {
             getLog().info("");
             getLog().info("hk2-inhabitant-generator generating into location " + getOutputDirectory().getAbsolutePath());
             getLog().info("");
         }
-        
-        LinkedList<String> arguments = new LinkedList<String>();
-        
+
+        LinkedList<String> arguments = new LinkedList<>();
+
         arguments.add(HabitatGenerator.FILE_ARG);
         arguments.add(getOutputDirectory().getAbsolutePath());
-        
+
         if (verbose) {
             arguments.add(HabitatGenerator.VERBOSE_ARG);
         }
-        
+
         if (locator != null) {
             arguments.add(HabitatGenerator.LOCATOR_ARG);
             arguments.add(locator);
         }
-        
+
         arguments.add(HabitatGenerator.SEARCHPATH_ARG);
         arguments.add(getBuildClasspath());
-        
+
         if (getNoSwap()) {
             arguments.add(HabitatGenerator.NOSWAP_ARG);
         }
-        
+
         if (!includeDate) {
             arguments.add(HabitatGenerator.NO_DATE_ARG);
         }
-        
+
         if (isWar()) {
             // For WAR files, the hk2-locator files goes under WEB-INF/classes/hk2-locator, not META-INF/hk2-locator
-            
+
             File outDir = new File(targetDirectory, project.getBuild().getFinalName());
             outDir = new File(outDir, WEB_INF);
             outDir = new File(outDir, CLASSES);
             outDir = new File(outDir, HabitatGenerator.HK2_LOCATOR);
-            
+
             arguments.add(HabitatGenerator.DIRECTORY_ARG);
             arguments.add(outDir.getAbsolutePath());
         }
-        
+
         String argv[] = arguments.toArray(new String[arguments.size()]);
-        
+
         int result = HabitatGenerator.embeddedMain(argv);
         if (result != 0) {
             throw new MojoFailureException("Could not generate inhabitants file for " + getOutputDirectory());
         }
     }
-    
+
     @SuppressWarnings("unchecked")
     private String getBuildClasspath() {
         StringBuilder sb = new StringBuilder();
-        
+
         sb.append(project.getBuild().getOutputDirectory());
         sb.append(File.pathSeparator);
-        
+
         if (!getOutputDirectory().getAbsolutePath().equals(
                 project.getBuild().getOutputDirectory())) {
-            
+
             sb.append(getOutputDirectory().getAbsolutePath());
             sb.append(File.pathSeparator);
         }
 
-        List<Artifact> artList = new ArrayList<Artifact>(project.getArtifacts());
+        List<Artifact> artList = new ArrayList<>(project.getArtifacts());
         Iterator<Artifact> i = artList.iterator();
-        
+
         if (i.hasNext()) {
             sb.append(i.next().getFile().getPath());
 
@@ -182,7 +183,7 @@ public abstract class AbstractInhabitantsGeneratorMojo extends AbstractMojo {
                 sb.append(i.next().getFile().getPath());
             }
         }
-        
+
         String classpath = sb.toString();
         if(verbose){
             getLog().info("");
@@ -192,5 +193,5 @@ public abstract class AbstractInhabitantsGeneratorMojo extends AbstractMojo {
             getLog().info("");
         }
         return classpath;
-    }      
+    }
 }

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/InhabitantsGeneratorMojo.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/InhabitantsGeneratorMojo.java
@@ -21,19 +21,19 @@ import java.io.File;
 
 /**
  * Generates inhabitant
- * 
+ *
  * @goal generate-inhabitants
- * @phase process-classes 
+ * @phase process-classes
  * @threadSafe true
  * @requiresDependencyResolution test
  */
 public class InhabitantsGeneratorMojo extends AbstractInhabitantsGeneratorMojo {
-    
+
     /**
-     * @parameter expression="${project.build.outputDirectory}"
+     * @parameter property="project.build.outputDirectory"
      */
     private File outputDirectory;
-    
+
     /**
      * @parameter default-value="true"
      */

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/TestInhabitantsGeneratorMojo.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/TestInhabitantsGeneratorMojo.java
@@ -21,19 +21,19 @@ import java.io.File;
 
 /**
  * Generates inhabitant
- * 
+ *
  * @goal generate-test-inhabitants
  * @phase test-compile
  * @threadSafe true
  * @requiresDependencyResolution test
  */
 public class TestInhabitantsGeneratorMojo extends AbstractInhabitantsGeneratorMojo {
-    
+
     /**
-     * @parameter expression="${project.build.testOutputDirectory}"
+     * @parameter property="project.build.testOutputDirectory"
      */
     private File outputDirectory;
-    
+
     /**
      * @parameter default-value="false"
      */

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -44,17 +44,14 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-osgi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-container-default</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -44,13 +44,20 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-osgi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-container-default</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -67,5 +74,5 @@
             </plugin>
         </plugins>
     </build>
-    
+
 </project>

--- a/maven-plugins/osgiversion-maven-plugin/src/main/java/com/sun/enterprise/module/maven/OsgiVersionMojo.java
+++ b/maven-plugins/osgiversion-maven-plugin/src/main/java/com/sun/enterprise/module/maven/OsgiVersionMojo.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,11 +17,11 @@
 
 package com.sun.enterprise.module.maven;
 
-import org.glassfish.hk2.maven.Version;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
+import org.glassfish.hk2.maven.Version;
 
 /**
  * Converts the project version into the OSGi format and
@@ -39,12 +40,12 @@ public class OsgiVersionMojo extends AbstractMojo {
     /**
      * The maven project.
      *
-     * @parameter expression="${project}"
+     * @parameter property="project"
      * @required
      * @readonly
      */
     protected MavenProject project;
-    
+
     /**
      * Flag used to determine what components of the version will be used
      * in OSGi version.

--- a/maven-plugins/osgiversion-maven-plugin/src/main/java/org/glassfish/hk2/maven/Version.java
+++ b/maven-plugins/osgiversion-maven-plugin/src/main/java/org/glassfish/hk2/maven/Version.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -23,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.maven.shared.osgi.DefaultMaven2OsgiConverter;
 import org.apache.maven.shared.osgi.Maven2OsgiConverter;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  *
@@ -36,8 +36,8 @@ public class Version {
         minor,
         micro,
         qualifier
-    };
-    
+    }
+
     private static final int DIGITS_INDEX = 1;
     public static final Pattern STANDARD_PATTERN = Pattern.compile(
             "^((?:\\d+\\.)*\\d+)" // digit(s) and '.' repeated - followed by digit (version digits 1.22.0, etc)
@@ -75,11 +75,9 @@ public class Version {
     private List<String> parseDigits(String vStr) {
         Matcher m = STANDARD_PATTERN.matcher(vStr);
         if (m.matches()) {
-            return Arrays.asList(StringUtils.split(
-                    m.group(DIGITS_INDEX),
-                    "."));
+            return Arrays.asList(m.group(DIGITS_INDEX).split("\\."));
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     public int getMajorVersion() {
@@ -93,7 +91,7 @@ public class Version {
     public int getIncrementalVersion() {
         return incremental;
     }
-    
+
     public String getQualifier(){
         return qualifier;
     }
@@ -101,7 +99,7 @@ public class Version {
     private static String formatString4Osgi(String s){
         return s.replaceAll("-", "_").replaceAll("\\.", "_");
     }
-    
+
     public String convertToOsgi(COMPONENT comToDrop) {
         Maven2OsgiConverter converter = new DefaultMaven2OsgiConverter();
 
@@ -126,13 +124,13 @@ public class Version {
                 }
             }
         }
-        
+
         // init version major.minor.micro
         String version = String.format("%s.%s.%s",
                 getMajorVersion(),
                 getMinorVersion(),
                 getIncrementalVersion());
-        
+
         // if there is a qualifier, add it
         if(!getQualifier().isEmpty()){
             version = String.format("%s.%s",

--- a/osgi/adapter/pom.xml
+++ b/osgi/adapter/pom.xml
@@ -63,8 +63,12 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
@@ -73,6 +77,11 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.cmpn</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -332,9 +332,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.5.0</version>
                     <configuration>
-                        <additionalOptions>
-                            <additionalOption>-Xdoclint:none</additionalOption>
-                        </additionalOptions>
+                        <doclint>none</doclint>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
                     <version>3.5.0</version>
                     <configuration>
                         <additionalOptions>
-                            <additionalOption>${javadoc.options}</additionalOption>
+                            <additionalOption>-Xdoclint:none</additionalOption>
                         </additionalOptions>
                     </configuration>
                 </plugin>
@@ -949,16 +949,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>javadoc-jdk8+</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <javadoc.options>-Xdoclint:none</javadoc.options>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -552,16 +552,30 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>3.9.1</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>3.9.1</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.sun.codemodel</groupId>
                 <artifactId>codemodel</artifactId>
                 <version>2.6</version>
             </dependency>
+            <!-- FIXME: This dependency is obsoleted and abandoned!!! -->
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-osgi</artifactId>
                 <version>0.2.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>args4j</groupId>
@@ -618,6 +632,12 @@
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.cmpn</artifactId>
                 <version>7.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>8.1.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -68,12 +68,17 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <version>${jakarta-inject.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
* Originally reported by @arjantijms 
* deprecated javadocs in maven plugins
* JUnit4 URL changed
* The maven-osgi dependency is dead, we should get rid of it. Now I replaced it's dependencies by latest, seems it is working
* spring module had conflicts on classpath