### PR TITLE
fix Reproducible Builds issues

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -37,6 +37,7 @@
     <properties>
         <asm.version>9.5</asm.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
+        <project.build.outputTimestamp>2023-04-09T08:38:05Z</project.build.outputTimestamp>
     </properties>
 
     <dependencyManagement>

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/AbstractInhabitantsGeneratorMojo.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/maven/AbstractInhabitantsGeneratorMojo.java
@@ -57,9 +57,9 @@ public abstract class AbstractInhabitantsGeneratorMojo extends AbstractMojo {
     private boolean verbose;
 
     /**
-     * @parameter default-value=true
+     * @parameter default-value="true"
      */
-    private final boolean includeDate = true;
+    private boolean includeDate;
 
     /**
      * @parameter

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
     <properties>
         <jdk.version>11</jdk.version>
         <mvn.version>3.2.5</mvn.version>
+        <project.build.outputTimestamp>2023-04-09T08:38:05Z</project.build.outputTimestamp>
 
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <jakarta.json.version>2.1.1</jakarta.json.version>

--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,9 @@
                     <groupId>org.glassfish.hk2</groupId>
                     <artifactId>hk2-inhabitant-generator</artifactId>
                     <version>${project.version}</version>
+                    <configuration>
+                        <includeDate>false</includeDate>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
"now" date was injected in generated `META-INF/hk2-locator/default`, and parameter `includeDate` to disable it was ignored because plugin variable was marked final

fixes Reproducible Builds issues found in previous release: https://github.com/jvm-repo-rebuild/reproducible-central/tree/master/content/org/glassfish/hk2