### PR TITLE
Bump required JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     </issueManagement>
 
     <properties>
-        <jdk.version>11</jdk.version>
+        <jdk.version>17</jdk.version>
         <mvn.version>3.2.5</mvn.version>
         <project.build.outputTimestamp>2023-04-09T08:38:05Z</project.build.outputTimestamp>
 


### PR DESCRIPTION
17 needed due to
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project spring-bridge: Compilation failure: Compilation failure: [ERROR] spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java:[24,41] cannot access org.springframework.beans.factory.ObjectFactory
[ERROR]   bad class file: org/springframework/spring-beans/6.0.11/spring-beans-6.0.11.jar(/org/springframework/beans/factory/ObjectFactory.class)
[ERROR]     class file has wrong version 61.0, should be 55.0
[ERROR]     Please remove or make sure it appears in the correct subdirectory of the classpath.
```