### PR TITLE
SerialVersionUID fix for all the classes that implement Serializable

### DIFF
--- a/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
@@ -40,7 +40,8 @@ import java.util.*;
  * @author Kohsuke Kawaguchi
  */
 public final class ModuleMetadata implements Serializable {
-
+    private static long serialVersionUID = 7136851720280194479L;
+    
     /**
      * META-INF/hk2-locator/* cache
      */
@@ -63,6 +64,8 @@ public final class ModuleMetadata implements Serializable {
     }
 
     public static final class Entry implements Serializable {
+        private static long serialVersionUID = 5761635763438873618L;
+        
         public final List<String> providerNames = new ArrayList<String>();
         public final List<URL> resources = new ArrayList<URL>();
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/ByteArrayInhabitantsDescriptor.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/ByteArrayInhabitantsDescriptor.java
@@ -30,7 +30,8 @@ import com.sun.enterprise.module.InhabitantsDescriptor;
  * @author Jerome Dochez
  */
 public class ByteArrayInhabitantsDescriptor implements InhabitantsDescriptor, Serializable {
-
+    private static final long serialVersionUID = -8608625418273737284L;
+    	
     public final String systemId;
     private final byte[] data;
 

--- a/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/OSGiModuleDefinition.java
+++ b/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/OSGiModuleDefinition.java
@@ -51,7 +51,8 @@ import com.sun.enterprise.module.common_impl.LogHelper;
  * @author Sanjeeb.Sahoo@Sun.COM
  */
 public class OSGiModuleDefinition implements ModuleDefinition, Serializable {
-
+    private static final long serialVersionUID = 2622853607700859151L;
+    
     private String name;
     private String bundleName;
     private URI location;
@@ -389,7 +390,8 @@ public class OSGiModuleDefinition implements ModuleDefinition, Serializable {
     }
 
     private static class SerializableManifest extends Manifest implements Serializable {
-
+        private static final long serialVersionUID = -3807768397772201563L;
+        
         private SerializableManifest()
         {
         }


### PR DESCRIPTION
##### Motivation:

In file: OSGiModuleDefinition.java, ByteArrayInhabitantsDescriptor.java and ModuleMetadata.java, some classes explicitly implement serializable but they do not contain any serialVersionUID field. The compiler generates one by default in such scenarios, but the generated id is dependent on compiler implementation and may cause unwanted problems during deserialization.

##### The Role of serialVersionUID:

The primary role of serialVersionUID is to provide version control during deserialization. When we deserialize an object, the JVM checks whether the serialVersionUID of the serialized data matches the serialVersionUID of the class in the current classpath. If they match, the deserialization proceeds without issues. However, if they do not match, programmers encounter InvalidClassException.

As, serialVersionUID servers the purpose of version control of class during serialization-deserialization, without a serialVersionUID, we risk breaking backward compatibility when we make changes to our classes, which can lead to unexpected issues and errors during deserialization.

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.