### PR TITLE
Replace synchronized by ReentrantLock

### DIFF
--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/Parser.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/Parser.java
@@ -79,8 +79,8 @@ public class Parser implements Closeable {
                  context.logger.log(Level.FINE, "Await iterating at " + System.currentTimeMillis() + " waiting for " + futures.size());
             }
             Future<Result> f;
+            futuresLock.lock();
             try {
-                futuresLock.lock();
                 f = futures.pop();
             } catch(EmptyStackException e) {
                 // it's ok, another thread took the load from us.
@@ -290,8 +290,8 @@ public class Parser implements Closeable {
                     }
                 }
             });
+            futuresLock.lock();
             try {
-                futuresLock.lock();
                 futures.add(future);
             } finally {
                 futuresLock.unlock();
@@ -306,8 +306,8 @@ public class Parser implements Closeable {
     }
 
     private Types getResult(URI uri) {
+        thislock.lock();
         try {
-            thislock.lock();
             return processedURI.get(uri.getSchemeSpecificPart());
         } finally {
             thislock.unlock();
@@ -315,8 +315,8 @@ public class Parser implements Closeable {
     }
                                
     private void saveResult(URI uri, Types types) {
+        thislock.lock();
         try {
-            thislock.lock();
             this.processedURI.put(uri.getPath(), types);
         } finally {
             thislock.unlock();

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/ParsingContext.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/ParsingContext.java
@@ -181,8 +181,8 @@ public class ParsingContext {
     Map<URI, TypeBuilder> builders = new HashMap<URI, TypeBuilder>();
 
     public TypeBuilder getTypeBuilder(URI definingURI) {
+        lock.lock();
         try {
-            lock.lock();
             TypeBuilder builder = builders.get(definingURI);
             if (builder==null) {
                 builder = new TypesImpl(types, definingURI);

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/ParsingContext.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/ParsingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReentrantLock;
 import java.net.URI;
 import java.util.logging.Logger;
 
@@ -149,6 +150,7 @@ public class ParsingContext {
     final Logger logger;
     final ParsingConfig config;
     final ResourceLocator locator;
+    final ReentrantLock lock = new ReentrantLock();
 
     private ParsingContext(Builder builder) {
 //        Runtime runtime = Runtime.getRuntime();
@@ -178,13 +180,18 @@ public class ParsingContext {
 
     Map<URI, TypeBuilder> builders = new HashMap<URI, TypeBuilder>();
 
-    public synchronized TypeBuilder getTypeBuilder(URI definingURI) {
-        TypeBuilder builder = builders.get(definingURI);
-        if (builder==null) {
-            builder = new TypesImpl(types, definingURI);
-            builders.put(definingURI, builder);
+    public TypeBuilder getTypeBuilder(URI definingURI) {
+        try {
+            lock.lock();
+            TypeBuilder builder = builders.get(definingURI);
+            if (builder==null) {
+                builder = new TypesImpl(types, definingURI);
+                builders.put(definingURI, builder);
+            }
+            return builder;
+        } finally {
+            lock.unlock();
         }
-        return builder;
     }
 
     /**

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotatedElementImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotatedElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.classmodel.reflect.impl;
 
 import org.glassfish.hk2.classmodel.reflect.*;
 
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.*;
 
 /**
@@ -26,7 +27,8 @@ import java.util.*;
  * @author Jerome Dochez
  */
 public class AnnotatedElementImpl implements AnnotatedElement {
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final String name;
 
     private final List<AnnotationModel> annotations = new ArrayList<AnnotationModel>();
@@ -42,8 +44,13 @@ public class AnnotatedElementImpl implements AnnotatedElement {
         return name;
     }
 
-    synchronized void addAnnotation(AnnotationModel annotation) {
-        annotations.add(annotation);
+    void addAnnotation(AnnotationModel annotation) {
+        try {
+            lock.lock();
+            annotations.add(annotation);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotatedElementImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/AnnotatedElementImpl.java
@@ -45,8 +45,8 @@ public class AnnotatedElementImpl implements AnnotatedElement {
     }
 
     void addAnnotation(AnnotationModel annotation) {
+        lock.lock();
         try {
-            lock.lock();
             annotations.add(annotation);
         } finally {
             lock.unlock();

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ClassModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ClassModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,20 +20,27 @@ import org.glassfish.hk2.classmodel.reflect.*;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Implementation of a class model
  */
 public class ClassModelImpl extends ExtensibleTypeImpl<ClassModel> implements ClassModel {
 
+    private final ReentrantLock lock = new ReentrantLock();
     final List<FieldModel> fields = new ArrayList<FieldModel > ();
 
     public ClassModelImpl(String name, TypeProxy<Type> sink, TypeProxy parent) {
         super(name, sink, parent);
     }
     
-    synchronized void addField(FieldModel field) {
-        fields.add(field);
+    void addField(FieldModel field) {
+        try {
+            lock.lock();
+            fields.add(field);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ClassModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ClassModelImpl.java
@@ -35,8 +35,8 @@ public class ClassModelImpl extends ExtensibleTypeImpl<ClassModel> implements Cl
     }
     
     void addField(FieldModel field) {
+        lock.lock();
         try {
-            lock.lock();
             fields.add(field);
         } finally {
             lock.unlock();

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ExtensibleTypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ExtensibleTypeImpl.java
@@ -49,8 +49,8 @@ public abstract class ExtensibleTypeImpl<T extends ExtensibleType> extends TypeI
     }
     
     public TypeProxy<?> setParent(final TypeProxy<?> parent) {
+        lock.lock();
         try {
-            lock.lock();
             if (null == this.parent) { 
                 this.parent = parent;
             }

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
@@ -39,8 +39,8 @@ class ParameterizedInterfaceModelImpl implements ParameterizedInterfaceModel {
     }
 
     void addParameterizedType(ParameterizedInterfaceModel type) {
-        try {
-            lock.lock();
+        lock.lock();
+            try {
             parameterizedTypes.add(type);
         } finally {
             lock.unlock();

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/ParameterizedInterfaceModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import org.glassfish.hk2.classmodel.reflect.InterfaceModel;
 import org.glassfish.hk2.classmodel.reflect.ParameterizedInterfaceModel;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Implementation of the {@link ParameterizedInterfaceModel}
@@ -29,6 +30,7 @@ import java.util.*;
  */
 class ParameterizedInterfaceModelImpl implements ParameterizedInterfaceModel {
 
+    private final ReentrantLock lock = new ReentrantLock();
     final TypeProxy<InterfaceModel> rawInterface;
     final List<ParameterizedInterfaceModel> parameterizedTypes = new ArrayList<ParameterizedInterfaceModel>();
 
@@ -36,8 +38,13 @@ class ParameterizedInterfaceModelImpl implements ParameterizedInterfaceModel {
         this.rawInterface = rawInterface;
     }
 
-    synchronized void addParameterizedType(ParameterizedInterfaceModel type) {
-        parameterizedTypes.add(type);
+    void addParameterizedType(ParameterizedInterfaceModel type) {
+        try {
+            lock.lock();
+            parameterizedTypes.add(type);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeImpl.java
@@ -49,8 +49,8 @@ public class TypeImpl extends AnnotatedElementImpl implements Type {
     }
 
     void addDefiningURI(URI uri) {
+        lock.lock();
         try {
-            lock.lock();
             definingURIs.add(uri);
             try {
                 File file = new File(uri);
@@ -76,8 +76,8 @@ public class TypeImpl extends AnnotatedElementImpl implements Type {
     }
 
     void addMethod(MethodModelImpl m) {
+        lock.lock();
         try {
-            lock.lock();
             methods.add(m);
         } finally {
             lock.unlock();

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeProxy.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.hk2.classmodel.reflect.impl;
 import org.glassfish.hk2.classmodel.reflect.*;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Proxy for types, used in place until the type can be properly instantiated.
@@ -35,6 +36,8 @@ public class TypeProxy<T extends Type> {
     private final List<Member> fieldRefs = new ArrayList<Member>();
     private final List<Type> subTypeRefs = new ArrayList<Type>();
     private final List<ClassModel> implementations = new ArrayList<ClassModel>();
+    // Referenced also by TypesImpl
+    final ReentrantLock lock = new ReentrantLock();
 
 
     /**
@@ -76,24 +79,39 @@ public class TypeProxy<T extends Type> {
         public void valueSet(T value);
     }
 
-    public synchronized void addFieldRef(FieldModel field) {
-        fieldRefs.add(field);
+    public void addFieldRef(FieldModel field) {
+        try {
+            lock.lock();
+            fieldRefs.add(field);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public List<Member> getRefs() {
         return Collections.unmodifiableList(fieldRefs);
     }
 
-    public synchronized void addSubTypeRef(Type subType) {
-        subTypeRefs.add(subType);
+    public void addSubTypeRef(Type subType) {
+        try {
+            lock.lock();
+            subTypeRefs.add(subType);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public List<Type> getSubTypeRefs() {
         return Collections.unmodifiableList(subTypeRefs);
     }
 
-    public synchronized void addImplementation(ClassModel classModel) {
-        implementations.add(classModel);
+    public void addImplementation(ClassModel classModel) {
+        try {
+            lock.lock();
+            implementations.add(classModel);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public List<ClassModel> getImplementations() {

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeProxy.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypeProxy.java
@@ -80,8 +80,8 @@ public class TypeProxy<T extends Type> {
     }
 
     public void addFieldRef(FieldModel field) {
+        lock.lock();
         try {
-            lock.lock();
             fieldRefs.add(field);
         } finally {
             lock.unlock();
@@ -93,8 +93,8 @@ public class TypeProxy<T extends Type> {
     }
 
     public void addSubTypeRef(Type subType) {
+        lock.lock();
         try {
-            lock.lock();
             subTypeRefs.add(subType);
         } finally {
             lock.unlock();
@@ -106,8 +106,8 @@ public class TypeProxy<T extends Type> {
     }
 
     public void addImplementation(ClassModel classModel) {
+        lock.lock();
         try {
-            lock.lock();
             implementations.add(classModel);
         } finally {
             lock.unlock();

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesCtr.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesCtr.java
@@ -92,8 +92,8 @@ public class TypesCtr implements Types {
             TypeProxy<Type> tmp = unknownTypesStorage.get(name);
             // in our unknown type pool ?
             if (tmp!=null) {
+                unknownTypesStorageLock.lock();
                 try {
-                    unknownTypesStorageLock.lock();
                     typeProxy = unknownTypesStorage.remove(name);
                     if (typeProxy == null) { 
                         typeProxy = tmp; 

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,7 +54,8 @@ public class TypesImpl implements TypeBuilder {
         Class<? extends Type> requestedType = getType(access);
 
         TypeProxy<Type> typeProxy = types.getHolder(name, requestedType);
-        synchronized(typeProxy) {
+        try {
+            typeProxy.lock.lock();
             final Type type = typeProxy.get();
             TypeImpl result;
             if (null == type) {
@@ -76,6 +77,8 @@ public class TypesImpl implements TypeBuilder {
                 }
                 return impl;
             }
+        } finally {
+            typeProxy.lock.unlock();
         }
     }
 

--- a/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
+++ b/class-model/src/main/java/org/glassfish/hk2/classmodel/reflect/impl/TypesImpl.java
@@ -54,8 +54,8 @@ public class TypesImpl implements TypeBuilder {
         Class<? extends Type> requestedType = getType(access);
 
         TypeProxy<Type> typeProxy = types.getHolder(name, requestedType);
+        typeProxy.lock.lock();
         try {
-            typeProxy.lock.lock();
             final Type type = typeProxy.get();
             TypeImpl result;
             if (null == type) {

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Created by IntelliJ IDEA.
@@ -40,13 +41,14 @@ public class ClassModelTestsUtils {
 
     static Types types = null;
 
+    private final static ReentrantLock lock = new ReentrantLock();
     private final static ClassModelTestsUtils instance = new ClassModelTestsUtils();
 
 
     public static Types getTypes() throws IOException, InterruptedException {
 
-        synchronized(instance) {
-
+        try {
+            lock.lock();
             if (types == null) {
                 File userDir = new File(System.getProperty("user.dir"));
                 File modelDir = new File(userDir, "target" + File.separator + "test-classes");
@@ -81,6 +83,8 @@ public class ClassModelTestsUtils {
                     types = pc.getTypes();
                 }
             }
+        } finally {
+            lock.unlock();
         }
         return types;
     }

--- a/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
+++ b/class-model/src/test/java/org/glassfish/hk2/classmodel/reflect/test/ClassModelTestsUtils.java
@@ -47,8 +47,8 @@ public class ClassModelTestsUtils {
 
     public static Types getTypes() throws IOException, InterruptedException {
 
+        lock.lock();
         try {
-            lock.lock();
             if (types == null) {
                 File userDir = new File(System.getProperty("user.dir"));
                 File modelDir = new File(userDir, "target" + File.separator + "test-classes");

--- a/examples/events/threaded/src/test/java/org/glassfish/examples/events/threaded/tests/EventSubscriberService.java
+++ b/examples/events/threaded/src/test/java/org/glassfish/examples/events/threaded/tests/EventSubscriberService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +16,6 @@
 
 package org.glassfish.examples.events.threaded.tests;
 
-import java.util.concurrent.locks.ReentrantLock;
-
 import javax.inject.Singleton;
 
 import org.glassfish.hk2.api.messaging.MessageReceiver;
@@ -33,7 +31,7 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service @Singleton @MessageReceiver
 public class EventSubscriberService {
-    private final ReentrantLock lock = new ReentrantLock();
+    private final Object lock = new Object();
     private Long eventThreadId = null;
     
     /**
@@ -44,13 +42,10 @@ public class EventSubscriberService {
      */
     @SuppressWarnings("unused")
     private void eventSubscriber(@SubscribeTo Event event) {
-        try {
-            lock.lock();
+        synchronized (lock) {
             eventThreadId = Thread.currentThread().getId();
             
             lock.notifyAll();
-        } finally {
-            lock.unlock();
         }
         
     }
@@ -62,15 +57,12 @@ public class EventSubscriberService {
      * @throws InterruptedException If the thread gets interrupted
      */
     public long getEventThread() throws InterruptedException {
-        try {
-            lock.lock();
+        synchronized (lock) {
             while (eventThreadId == null) {
                 lock.wait();
             }
             
             return eventThreadId;
-        } finally {
-            lock.unlock();
         }
     }
 

--- a/examples/operations/src/main/java/org/glassfish/examples/operations/application/internal/BankingServiceImpl.java
+++ b/examples/operations/src/main/java/org/glassfish/examples/operations/application/internal/BankingServiceImpl.java
@@ -58,8 +58,8 @@ public class BankingServiceImpl implements BankingService {
     private final Map<String, OperationHandle<WithdrawalScope>> withdrawers = new HashMap<String, OperationHandle<WithdrawalScope>>();
     
     private OperationHandle<DepositScope> getDepositBankHandle(String bank) {
+        lock.lock();
         try {
-            lock.lock();
             OperationHandle<DepositScope> depositor = depositors.get(bank);
             if (depositor == null) {
                 // create and start it
@@ -74,8 +74,8 @@ public class BankingServiceImpl implements BankingService {
     }
     
     private OperationHandle<WithdrawalScope> getWithdrawerBankHandle(String bank) {
+        lock.lock();
         try {
-            lock.lock();
             OperationHandle<WithdrawalScope> withdrawer = withdrawers.get(bank);
             if (withdrawer == null) {
                 // create and start it
@@ -95,8 +95,8 @@ public class BankingServiceImpl implements BankingService {
     @Override
     public int transferFunds(String withdrawlBank, long withdrawlAccount,
             String depositorBank, long depositAccount, int funds) {
+        lock.lock();
         try {
-            lock.lock();
             OperationHandle<DepositScope> depositor = getDepositBankHandle(depositorBank);
             OperationHandle<WithdrawalScope> withdrawer = getWithdrawerBankHandle(withdrawlBank);
             

--- a/examples/operations/src/main/java/org/glassfish/examples/operations/application/internal/BankingServiceImpl.java
+++ b/examples/operations/src/main/java/org/glassfish/examples/operations/application/internal/BankingServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.examples.operations.application.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -52,52 +53,68 @@ public class BankingServiceImpl implements BankingService {
     @Inject
     private WithdrawalService withdrawerAgent;
     
+    private final ReentrantLock lock = new ReentrantLock();
     private final Map<String, OperationHandle<DepositScope>> depositors = new HashMap<String, OperationHandle<DepositScope>>();
     private final Map<String, OperationHandle<WithdrawalScope>> withdrawers = new HashMap<String, OperationHandle<WithdrawalScope>>();
     
-    private synchronized OperationHandle<DepositScope> getDepositBankHandle(String bank) {
-        OperationHandle<DepositScope> depositor = depositors.get(bank);
-        if (depositor == null) {
-            // create and start it
-            depositor = manager.createOperation(DepositScopeImpl.INSTANCE);
-            depositors.put(bank, depositor);
+    private OperationHandle<DepositScope> getDepositBankHandle(String bank) {
+        try {
+            lock.lock();
+            OperationHandle<DepositScope> depositor = depositors.get(bank);
+            if (depositor == null) {
+                // create and start it
+                depositor = manager.createOperation(DepositScopeImpl.INSTANCE);
+                depositors.put(bank, depositor);
+            }
+            
+            return depositor;
+        } finally {
+            lock.unlock();
         }
-        
-        return depositor;
     }
     
-    private synchronized OperationHandle<WithdrawalScope> getWithdrawerBankHandle(String bank) {
-        OperationHandle<WithdrawalScope> withdrawer = withdrawers.get(bank);
-        if (withdrawer == null) {
-            // create and start it
-            withdrawer = manager.createOperation(WithdrawalScopeImpl.INSTANCE);
-            withdrawers.put(bank, withdrawer);
+    private OperationHandle<WithdrawalScope> getWithdrawerBankHandle(String bank) {
+        try {
+            lock.lock();
+            OperationHandle<WithdrawalScope> withdrawer = withdrawers.get(bank);
+            if (withdrawer == null) {
+                // create and start it
+                withdrawer = manager.createOperation(WithdrawalScopeImpl.INSTANCE);
+                withdrawers.put(bank, withdrawer);
+            }
+            
+            return withdrawer;
+        } finally {
+            lock.unlock();
         }
-        
-        return withdrawer;
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.examples.operations.application.BankingService#transferFunds(java.lang.String, long, java.lang.String, long, int)
      */
     @Override
-    public synchronized int transferFunds(String withdrawlBank, long withdrawlAccount,
+    public int transferFunds(String withdrawlBank, long withdrawlAccount,
             String depositorBank, long depositAccount, int funds) {
-        OperationHandle<DepositScope> depositor = getDepositBankHandle(depositorBank);
-        OperationHandle<WithdrawalScope> withdrawer = getWithdrawerBankHandle(withdrawlBank);
-        
-        // Set the context for the transfer
-        depositor.resume();
-        withdrawer.resume();
-        
-        // At this point the scopes are set properly, we can just call the service!
         try {
-            return transferAgent.doTransfer(depositAccount, withdrawlAccount, funds);
-        }
-        finally {
-            // Turn off the two scopes
-            withdrawer.suspend();
-            depositor.suspend();
+            lock.lock();
+            OperationHandle<DepositScope> depositor = getDepositBankHandle(depositorBank);
+            OperationHandle<WithdrawalScope> withdrawer = getWithdrawerBankHandle(withdrawlBank);
+            
+            // Set the context for the transfer
+            depositor.resume();
+            withdrawer.resume();
+            
+            // At this point the scopes are set properly, we can just call the service!
+            try {
+                return transferAgent.doTransfer(depositAccount, withdrawlAccount, funds);
+            }
+            finally {
+                // Turn off the two scopes
+                withdrawer.suspend();
+                depositor.suspend();
+            }
+        } finally {
+            lock.unlock();
         }
         
     }

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/MultiException.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/MultiException.java
@@ -107,8 +107,8 @@ public class MultiException extends HK2RuntimeException {
      * not return null, but may return an empty object
      */
     public List<Throwable> getErrors() {
+        lock.lock();
         try {
-            lock.lock();
             return new LinkedList<Throwable>(throwables);
         } finally {
             lock.unlock();
@@ -121,8 +121,8 @@ public class MultiException extends HK2RuntimeException {
      * @param error The exception to add
      */
     public void addError(Throwable error) {
+        lock.lock();
         try {
-            lock.lock();
             throwables.add(error);
         } finally {
             lock.unlock();

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/MultiException.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/MultiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This exception can contain multiple other exceptions.
@@ -34,7 +35,7 @@ public class MultiException extends HK2RuntimeException {
      * For serialization
      */
     private static final long serialVersionUID = 2112432697858621044L;
-    private final Object lock = new byte[0]; // byte[0] is an arbitrary type that is Serializable
+    private final ReentrantLock lock = new ReentrantLock();
     private final List<Throwable> throwables = new LinkedList<Throwable>();
     private boolean reportToErrorService = true;
 
@@ -106,8 +107,11 @@ public class MultiException extends HK2RuntimeException {
      * not return null, but may return an empty object
      */
     public List<Throwable> getErrors() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return new LinkedList<Throwable>(throwables);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -117,8 +121,11 @@ public class MultiException extends HK2RuntimeException {
      * @param error The exception to add
      */
     public void addError(Throwable error) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             throwables.add(error);
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-api/src/main/java/org/glassfish/hk2/internal/ImmediateHelper.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/internal/ImmediateHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -86,7 +85,7 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     
     private final HashSet<Long> tidsWithWork = new HashSet<Long>();
     
-    private final ReentrantLock queueLock = new ReentrantLock();
+    private final Object queueLock = new Object();
     private boolean threadAvailable;
     private boolean outstandingJob;
     private boolean waitingForWork;
@@ -147,13 +146,10 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     
     @Override
     public void configurationChanged() {
-        try {
-            queueLock.lock();
+        synchronized (queueLock) {
             if (currentState.equals(ImmediateServiceState.SUSPENDED)) return;
             
             doWorkIfWeHaveSome();
-        } finally {
-            queueLock.unlock();
         }
     }
     
@@ -173,11 +169,9 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
         if (!(ErrorType.DYNAMIC_CONFIGURATION_FAILURE.equals(errorInformation.getErrorType()))) {
             // Only interested in dynamic configuration failures
             long tid = Thread.currentThread().getId();
-            try {
-                queueLock.lock();
+            
+            synchronized (queueLock) {
                 tidsWithWork.remove(tid);
-            } finally {
-                queueLock.unlock();
             }
             
             return;
@@ -190,11 +184,9 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
         if (info.getOperation().equals(Operation.BIND) ||
                 info.getOperation().equals(Operation.UNBIND)) {
             long tid = Thread.currentThread().getId();
-            try {
-                queueLock.lock();
+            
+            synchronized (queueLock) {
                 tidsWithWork.add(tid);
-            } finally {
-                queueLock.unlock();
             }
         }
         
@@ -208,8 +200,7 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     @Override
     public void run() {
         for(;;) {
-            try {
-                queueLock.lock();
+            synchronized (queueLock) {
                 long decayTime = this.decayTime;
                 
                 while (currentState.equals(ImmediateServiceState.RUNNING) &&
@@ -237,8 +228,6 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
                 }
                 
                 outstandingJob = false;
-            } finally {
-                queueLock.unlock();
             }
             
             immediateContext.doWork();
@@ -251,11 +240,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public Executor getExecutor() {
-        try {
-            queueLock.lock();
+        synchronized (queueLock) {
             return currentExecutor;
-        } finally {
-            queueLock.unlock();
         }
     }
 
@@ -264,15 +250,12 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public void setExecutor(Executor executor) throws IllegalStateException {
-        try  {
-            queueLock.lock();
+        synchronized (queueLock)  {
             if (currentState.equals(ImmediateServiceState.RUNNING)) {
                 throw new IllegalStateException("ImmediateSerivce attempt made to change executor while in RUNNING state");
             }
             
             currentExecutor = (executor == null) ? DEFAULT_EXECUTOR : executor ;
-        } finally {
-            queueLock.unlock();
         }
         
     }
@@ -282,11 +265,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public long getThreadInactivityTimeout() {
-        try {
-            queueLock.lock();
+        synchronized (queueLock) {
             return decayTime;
-        } finally {
-            queueLock.unlock();
         }
     }
 
@@ -296,15 +276,12 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     @Override
     public void setThreadInactivityTimeout(long timeInMillis)
             throws IllegalStateException {
-        try  {
-            queueLock.lock();
+        synchronized (queueLock)  {
             if (timeInMillis < 0) {
                 throw new IllegalArgumentException();
             }
             
             decayTime = timeInMillis;
-        } finally {
-            queueLock.unlock();
         }
         
     }
@@ -314,11 +291,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public ImmediateServiceState getImmediateState() {
-        try {
-            queueLock.lock();
+        synchronized (queueLock) {
             return currentState;
-        } finally {
-            queueLock.unlock();
         }
     }
 
@@ -327,8 +301,7 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public void setImmediateState(ImmediateServiceState state) {
-        try {
-            queueLock.lock();
+        synchronized (queueLock)  {
             if (state == null) throw new IllegalArgumentException();
             
             if (state == currentState) return;
@@ -337,8 +310,6 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
             if (currentState.equals(ImmediateServiceState.RUNNING)) {
                 doWorkIfWeHaveSome();
             }
-        } finally {
-            queueLock.unlock();
         }
         
     }

--- a/hk2-api/src/main/java/org/glassfish/hk2/internal/ImmediateHelper.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/internal/ImmediateHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -85,7 +86,7 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     
     private final HashSet<Long> tidsWithWork = new HashSet<Long>();
     
-    private final Object queueLock = new Object();
+    private final ReentrantLock queueLock = new ReentrantLock();
     private boolean threadAvailable;
     private boolean outstandingJob;
     private boolean waitingForWork;
@@ -146,10 +147,13 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     
     @Override
     public void configurationChanged() {
-        synchronized (queueLock) {
+        try {
+            queueLock.lock();
             if (currentState.equals(ImmediateServiceState.SUSPENDED)) return;
             
             doWorkIfWeHaveSome();
+        } finally {
+            queueLock.unlock();
         }
     }
     
@@ -169,9 +173,11 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
         if (!(ErrorType.DYNAMIC_CONFIGURATION_FAILURE.equals(errorInformation.getErrorType()))) {
             // Only interested in dynamic configuration failures
             long tid = Thread.currentThread().getId();
-            
-            synchronized (queueLock) {
+            try {
+                queueLock.lock();
                 tidsWithWork.remove(tid);
+            } finally {
+                queueLock.unlock();
             }
             
             return;
@@ -184,9 +190,11 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
         if (info.getOperation().equals(Operation.BIND) ||
                 info.getOperation().equals(Operation.UNBIND)) {
             long tid = Thread.currentThread().getId();
-            
-            synchronized (queueLock) {
+            try {
+                queueLock.lock();
                 tidsWithWork.add(tid);
+            } finally {
+                queueLock.unlock();
             }
         }
         
@@ -200,7 +208,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     @Override
     public void run() {
         for(;;) {
-            synchronized (queueLock) {
+            try {
+                queueLock.lock();
                 long decayTime = this.decayTime;
                 
                 while (currentState.equals(ImmediateServiceState.RUNNING) &&
@@ -228,6 +237,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
                 }
                 
                 outstandingJob = false;
+            } finally {
+                queueLock.unlock();
             }
             
             immediateContext.doWork();
@@ -240,8 +251,11 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public Executor getExecutor() {
-        synchronized (queueLock) {
+        try {
+            queueLock.lock();
             return currentExecutor;
+        } finally {
+            queueLock.unlock();
         }
     }
 
@@ -250,12 +264,15 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public void setExecutor(Executor executor) throws IllegalStateException {
-        synchronized (queueLock)  {
+        try  {
+            queueLock.lock();
             if (currentState.equals(ImmediateServiceState.RUNNING)) {
                 throw new IllegalStateException("ImmediateSerivce attempt made to change executor while in RUNNING state");
             }
             
             currentExecutor = (executor == null) ? DEFAULT_EXECUTOR : executor ;
+        } finally {
+            queueLock.unlock();
         }
         
     }
@@ -265,8 +282,11 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public long getThreadInactivityTimeout() {
-        synchronized (queueLock) {
+        try {
+            queueLock.lock();
             return decayTime;
+        } finally {
+            queueLock.unlock();
         }
     }
 
@@ -276,12 +296,15 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
     @Override
     public void setThreadInactivityTimeout(long timeInMillis)
             throws IllegalStateException {
-        synchronized (queueLock)  {
+        try  {
+            queueLock.lock();
             if (timeInMillis < 0) {
                 throw new IllegalArgumentException();
             }
             
             decayTime = timeInMillis;
+        } finally {
+            queueLock.unlock();
         }
         
     }
@@ -291,8 +314,11 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public ImmediateServiceState getImmediateState() {
-        synchronized (queueLock) {
+        try {
+            queueLock.lock();
             return currentState;
+        } finally {
+            queueLock.unlock();
         }
     }
 
@@ -301,7 +327,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
      */
     @Override
     public void setImmediateState(ImmediateServiceState state) {
-        synchronized (queueLock)  {
+        try {
+            queueLock.lock();
             if (state == null) throw new IllegalArgumentException();
             
             if (state == currentState) return;
@@ -310,6 +337,8 @@ public class ImmediateHelper implements DynamicConfigurationListener, Runnable,
             if (currentState.equals(ImmediateServiceState.RUNNING)) {
                 doWorkIfWeHaveSome();
             }
+        } finally {
+            queueLock.unlock();
         }
         
     }

--- a/hk2-api/src/main/java/org/glassfish/hk2/internal/ServiceLocatorFactoryImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/internal/ServiceLocatorFactoryImpl.java
@@ -210,8 +210,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
     }
     
     private static String getGeneratedName() {
+        sLock.lock();
         try {
-            sLock.lock();
             return GENERATED_NAME_PREFIX + name_count++;
         } finally {
             sLock.unlock();
@@ -247,8 +247,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
             Logger.getLogger().debug("ServiceFactoryImpl given create of " + name + " with parent " + parent +
                     " with generator " + generator + " and policy " + policy, new Throwable());
         }
+        lock.lock();
         try {
-            lock.lock();
             ServiceLocator retVal;
 
             if (name == null) {
@@ -306,8 +306,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
     public void addListener(ServiceLocatorListener listener) {
         if (listener == null) throw new IllegalArgumentException();
         
+        lock.lock();
         try {
-            lock.lock();
             if (listeners.contains(listener)) return;
             
             try {
@@ -331,8 +331,8 @@ public class ServiceLocatorFactoryImpl extends ServiceLocatorFactory {
     public void removeListener(ServiceLocatorListener listener) {
         if (listener == null) throw new IllegalArgumentException();
         
+        lock.lock();
         try {
-            lock.lock();
             listeners.remove(listener);
         } finally {
             lock.unlock();

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/AliasDescriptor.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/AliasDescriptor.java
@@ -230,8 +230,8 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      */
     @Override
     public Set<Annotation> getQualifierAnnotations() {
+        lock.lock();
         try {
-            lock.lock();
             ensureInitialized();
 
             if (qualifiers == null) {
@@ -248,8 +248,8 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
     
     @Override
     public Set<String> getQualifiers() {
+        lock.lock();
         try {
-            lock.lock();
             if (qualifierNames != null) return qualifierNames;
             
             qualifierNames = new HashSet<String>(descriptor.getQualifiers());
@@ -301,8 +301,8 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      */
     @SuppressWarnings("unchecked")
     private void ensureInitialized() {
+        lock.lock();
         try {
-            lock.lock();
             if (!initialized) {
                 // reify the underlying descriptor if needed
                 if (!descriptor.isReified()) {
@@ -350,8 +350,8 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
     @Override
     public int hashCode() {
         int retVal;
+        lock.lock();
         try {
-            lock.lock();
             retVal = descriptor.hashCode();
         } finally {
             lock.unlock();

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/AliasDescriptor.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/AliasDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Named;
 
@@ -62,6 +63,8 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      * For serialization
      */
     private static final long serialVersionUID = 2609895430798803508L;
+
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * The service locator.
@@ -226,28 +229,38 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      * @see org.glassfish.hk2.api.ActiveDescriptor#getQualifierAnnotations()
      */
     @Override
-    public synchronized Set<Annotation> getQualifierAnnotations() {
-        ensureInitialized();
+    public Set<Annotation> getQualifierAnnotations() {
+        try {
+            lock.lock();
+            ensureInitialized();
 
-        if (qualifiers == null) {
-            qualifiers = new HashSet<Annotation>(descriptor.getQualifierAnnotations());
-            if (getName() != null) {
-                qualifiers.add(new NamedImpl(getName()));
+            if (qualifiers == null) {
+                qualifiers = new HashSet<Annotation>(descriptor.getQualifierAnnotations());
+                if (getName() != null) {
+                    qualifiers.add(new NamedImpl(getName()));
+                }
             }
+            return qualifiers;
+        } finally {
+            lock.unlock();
         }
-        return qualifiers;
     }
     
     @Override
-    public synchronized Set<String> getQualifiers() {
-        if (qualifierNames != null) return qualifierNames;
-        
-        qualifierNames = new HashSet<String>(descriptor.getQualifiers());
-        if (getName() != null) {
-            qualifierNames.add(Named.class.getName());
+    public Set<String> getQualifiers() {
+        try {
+            lock.lock();
+            if (qualifierNames != null) return qualifierNames;
+            
+            qualifierNames = new HashSet<String>(descriptor.getQualifiers());
+            if (getName() != null) {
+                qualifierNames.add(Named.class.getName());
+            }
+            
+            return qualifierNames;
+        } finally {
+            lock.unlock();
         }
-        
-        return qualifierNames;
     }
 
     /* (non-Javadoc)
@@ -287,53 +300,61 @@ public class AliasDescriptor<T> extends AbstractActiveDescriptor<T> {
      * Ensure that this descriptor has been initialized.
      */
     @SuppressWarnings("unchecked")
-    private synchronized void ensureInitialized() {
-        if (!initialized) {
-            // reify the underlying descriptor if needed
-            if (!descriptor.isReified()) {
-                descriptor = (ActiveDescriptor<T>) locator.reifyDescriptor(descriptor);
-            }
+    private void ensureInitialized() {
+        try {
+            lock.lock();
+            if (!initialized) {
+                // reify the underlying descriptor if needed
+                if (!descriptor.isReified()) {
+                    descriptor = (ActiveDescriptor<T>) locator.reifyDescriptor(descriptor);
+                }
 
-            if (contract == null) {
+                if (contract == null) {
+                    initialized = true;
+                    return;
+                }
+
+                HK2Loader loader = descriptor.getLoader();
+
+                Type contractType = null;
+                try {
+                    if (loader != null) {
+                        contractType = loader.loadClass(contract);
+                    }
+                    else {
+                        Class<?> ic = descriptor.getImplementationClass();
+                        ClassLoader cl = null;
+                        if (ic != null) {
+                            cl = ic.getClassLoader();
+                        }
+                        if (cl == null) {
+                            cl = ClassLoader.getSystemClassLoader();
+                        }
+
+                        contractType = cl.loadClass(contract);
+                    }
+                }
+                catch (ClassNotFoundException e) {
+                    // do nothing
+                }
+
+                super.addContractType(contractType);
+
                 initialized = true;
-                return;
             }
-
-            HK2Loader loader = descriptor.getLoader();
-
-            Type contractType = null;
-            try {
-                if (loader != null) {
-                    contractType = loader.loadClass(contract);
-                }
-                else {
-                    Class<?> ic = descriptor.getImplementationClass();
-                    ClassLoader cl = null;
-                    if (ic != null) {
-                        cl = ic.getClassLoader();
-                    }
-                    if (cl == null) {
-                        cl = ClassLoader.getSystemClassLoader();
-                    }
-
-                    contractType = cl.loadClass(contract);
-                }
-            }
-            catch (ClassNotFoundException e) {
-                // do nothing
-            }
-
-            super.addContractType(contractType);
-
-            initialized = true;
+        } finally {
+            lock.unlock();
         }
     }
     
     @Override
     public int hashCode() {
         int retVal;
-        synchronized (this) {
+        try {
+            lock.lock();
             retVal = descriptor.hashCode();
+        } finally {
+            lock.unlock();
         }
         
         if (getName() != null) {

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/BuilderHelper.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/BuilderHelper.java
@@ -714,8 +714,8 @@ public class BuilderHelper {
             
             @Override
             public void setServiceData(Object serviceData) {
+                lock.lock();
                 try {
-                    lock.lock();
                     this.serviceData = serviceData;
                 } finally {
                     lock.unlock();
@@ -724,8 +724,8 @@ public class BuilderHelper {
 
             @Override
             public Object getServiceData() {
+                lock.lock();
                 try {
-                    lock.lock();
                     return serviceData;
                 } finally {
                     lock.unlock();

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/DescriptorImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/DescriptorImpl.java
@@ -206,10 +206,10 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	
 	@Override
 	public Set<String> getAdvertisedContracts() {
+	    lock.lock();
 	    try {
-	        lock.lock();
-	            if (contracts == null) return EMPTY_CONTRACTS_SET;
-	                return Collections.unmodifiableSet(contracts);
+	       if (contracts == null) return EMPTY_CONTRACTS_SET;
+	           return Collections.unmodifiableSet(contracts);
 	    } finally {
 	        lock.unlock();
 	    }
@@ -220,8 +220,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param addMe The contract to add.  May not be null
 	 */
 	public void addAdvertisedContract(String addMe) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (addMe == null) return;
                 if (contracts == null) contracts = new LinkedHashSet<String>();
                 contracts.add(addMe);
@@ -236,8 +236,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @return true if removeMe was removed from the set
 	 */
 	public boolean removeAdvertisedContract(String removeMe) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (removeMe == null || contracts == null) return false;
                 return contracts.remove(removeMe);
             } finally {
@@ -247,8 +247,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
 	@Override
 	public String getImplementation() {
+	    lock.lock();
             try {
-                lock.lock();
                 return implementation;
             } finally {
                 lock.unlock();
@@ -260,8 +260,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param implementation The implementation this descriptor should have
 	 */
     public void setImplementation(String implementation) {
+        lock.lock();
         try {
-            lock.lock();
             this.implementation = implementation;
         } finally {
             lock.unlock();
@@ -270,8 +270,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
 	@Override
 	public String getScope() {
+	    lock.lock();
 	    try {
-	        lock.lock();
 	        return scope;
 	    } finally {
 	        lock.unlock();
@@ -283,8 +283,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param scope The scope of this descriptor
 	 */
 	public void setScope(String scope) {
+	    lock.lock();
             try {
-                lock.lock();
                 this.scope = scope;
             } finally {
                 lock.unlock();
@@ -293,8 +293,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
 	@Override
 	public String getName() {
+	    lock.lock();
             try {
-                lock.lock();
                 return name;
             } finally {
                 lock.unlock();
@@ -306,8 +306,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param name The name for this descriptor
 	 */
 	public void setName(String name) {
+	    lock.lock();
             try {
-                lock.lock();
                 this.name = name;
             } finally {
                 lock.unlock();
@@ -316,8 +316,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
 	@Override
 	public Set<String> getQualifiers() {
+	    lock.lock();
             try {
-                lock.lock();
                 if (qualifiers == null) return EMPTY_QUALIFIER_SET;
                 return Collections.unmodifiableSet(qualifiers);
             } finally {
@@ -331,8 +331,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param addMe The fully qualified class name of the qualifier to add.  May not be null
 	 */
 	public void addQualifier(String addMe) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (addMe == null) return;
                 if (qualifiers == null) qualifiers = new LinkedHashSet<String>();
                 qualifiers.add(addMe);
@@ -348,8 +348,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @return true if the given qualifier was removed
 	 */
 	public boolean removeQualifier(String removeMe) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (removeMe == null) return false;
                 if (qualifiers == null) return false;
                 return qualifiers.remove(removeMe);
@@ -360,8 +360,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
     @Override
     public DescriptorType getDescriptorType() {
+        lock.lock();
         try {
-            lock.lock();
             return descriptorType;
         } finally {
             lock.unlock();
@@ -373,8 +373,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
      * @param descriptorType The descriptor type.  May not be null
      */
     public void setDescriptorType(DescriptorType descriptorType) {
+        lock.lock();
         try {
-            lock.lock();
             if (descriptorType == null) throw new IllegalArgumentException();
             this.descriptorType = descriptorType;
         } finally {
@@ -384,8 +384,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
     
     @Override
     public DescriptorVisibility getDescriptorVisibility() {
+        lock.lock();
         try {
-            lock.lock();
             return descriptorVisibility;
         } finally {
             lock.unlock();
@@ -397,8 +397,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
      * @param descriptorVisibility The visibility this descriptor should have
      */
     public void setDescriptorVisibility(DescriptorVisibility descriptorVisibility) {
+        lock.lock();
         try {
-            lock.lock();
             if (descriptorVisibility == null) throw new IllegalArgumentException();
             this.descriptorVisibility = descriptorVisibility;
         } finally {
@@ -408,8 +408,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
 	@Override
 	public Map<String, List<String>> getMetadata() {
+	    lock.lock();
 	    try {
-	        lock.lock();
 	        if (metadatas == null) return EMPTY_METADATAS_MAP;
 	            return Collections.unmodifiableMap(metadatas);
 	    } finally {
@@ -427,8 +427,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * should have
 	 */
 	public void setMetadata(Map<String, List<String>> metadata) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (metadatas == null) {
                     metadatas = new LinkedHashMap<String, List<String>>();
                 }
@@ -450,8 +450,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * to add to the metadata map
 	 */
 	public void addMetadata(Map<String, List<String>> metadata) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
                 
                 metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
@@ -468,8 +468,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param value The value to add.  May not be null
 	 */
 	public void addMetadata(String key, String value) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
                 ReflectionHelper.addMetadata(metadatas, key, value);
             } finally {
@@ -486,8 +486,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @return true if the value was removed
 	 */
 	public boolean removeMetadata(String key, String value) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (metadatas == null) return false;
                 return ReflectionHelper.removeMetadata(metadatas, key, value);
             } finally {
@@ -502,8 +502,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @return true if any value was removed
 	 */
 	public boolean removeAllMetadata(String key) {
+	    lock.lock();
             try {
-                lock.lock();
                 if (metadatas == null) return false;
                 return ReflectionHelper.removeAllMetadata(metadatas, key);
             } finally {
@@ -515,8 +515,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
      * Removes all metadata values
      */
     public void clearMetadata() {
+        lock.lock();
         try {
-            lock.lock();
             metadatas = null;
         } finally {
             lock.unlock();
@@ -528,8 +528,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
      */
     @Override
     public HK2Loader getLoader() {
+        lock.lock();
         try {
-            lock.lock();
             return loader;
         } finally {
             lock.unlock();
@@ -541,8 +541,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
      * @param loader The loader to use with this descriptor
      */
     public void setLoader(HK2Loader loader) {
+        lock.lock();
         try {
-            lock.lock();
             this.loader = loader;
         } finally {
             lock.unlock();
@@ -551,8 +551,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 
     @Override
     public int getRanking() {
+        lock.lock();
         try {
-            lock.lock();
             return rank;
         } finally {
             lock.unlock();
@@ -564,8 +564,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
      */
     @Override
     public int setRanking(int ranking) {
+        lock.lock();
         try {
-            lock.lock();
             int retVal = rank;
             rank = ranking;
             return retVal;
@@ -576,12 +576,12 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	
 	@Override
 	public Long getServiceId() {
-	        try {
-	            lock.lock();
-	            return id;
-	        } finally {
-	            lock.unlock();
-	        }
+	    lock.lock();
+	    try {
+	        return id;
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	/**
@@ -589,8 +589,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param id the service id for this descriptor
 	 */
 	public void setServiceId(Long id) {
+	    lock.lock();
 	    try {
-	        lock.lock();
 	        this.id = id;
 	    } finally {
 	        lock.unlock();
@@ -649,8 +649,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	
 	@Override
 	public Long getLocatorId() {
+	    lock.lock();
 	    try {
-	        lock.lock();
 	        return locatorId;
 	    } finally {
 	        lock.unlock();
@@ -662,8 +662,8 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param locatorId the locator id for this descriptor
 	 */
 	public void setLocatorId(Long locatorId) {
+	    lock.lock();
             try {
-                lock.lock();
                 this.locatorId = locatorId;
             } finally {
                 lock.unlock();
@@ -882,15 +882,15 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	}
 	
 	public String toString() {
+	    lock.lock();
 	    try {
-	        lock.lock();
-    	            StringBuffer sb = new StringBuffer("Descriptor(");
+	        StringBuffer sb = new StringBuffer("Descriptor(");
     	        
-    	            pretty(sb, this);
+	        pretty(sb, this);
     	        
-    	            sb.append(")");
+	        sb.append(")");
     	        
-    	            return sb.toString();
+	        return sb.toString();
 	    } finally {
 	        lock.unlock();
 	    }

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/DescriptorImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/DescriptorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +31,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -80,6 +81,7 @@ public class DescriptorImpl implements Descriptor, Externalizable {
     private final static Set<String> EMPTY_QUALIFIER_SET = Collections.emptySet();
     private final static Map<String, List<String>> EMPTY_METADATAS_MAP = Collections.emptyMap();
 	
+        private final ReentrantLock lock = new ReentrantLock();
 	private Set<String> contracts;
 	private String implementation;
 	private String name;
@@ -203,19 +205,29 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	}
 	
 	@Override
-	public synchronized Set<String> getAdvertisedContracts() {
-	    if (contracts == null) return EMPTY_CONTRACTS_SET;
-		return Collections.unmodifiableSet(contracts);
+	public Set<String> getAdvertisedContracts() {
+	    try {
+	        lock.lock();
+	            if (contracts == null) return EMPTY_CONTRACTS_SET;
+	                return Collections.unmodifiableSet(contracts);
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	/**
 	 * Adds an advertised contract to the set of contracts advertised by this descriptor
 	 * @param addMe The contract to add.  May not be null
 	 */
-	public synchronized void addAdvertisedContract(String addMe) {
-	    if (addMe == null) return;
-	    if (contracts == null) contracts = new LinkedHashSet<String>();
-	    contracts.add(addMe);
+	public void addAdvertisedContract(String addMe) {
+            try {
+                lock.lock();
+                if (addMe == null) return;
+                if (contracts == null) contracts = new LinkedHashSet<String>();
+                contracts.add(addMe);
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
@@ -223,54 +235,94 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param removeMe The contract to remove.  May not be null
 	 * @return true if removeMe was removed from the set
 	 */
-	public synchronized boolean removeAdvertisedContract(String removeMe) {
-	    if (removeMe == null || contracts == null) return false;
-	    return contracts.remove(removeMe);
+	public boolean removeAdvertisedContract(String removeMe) {
+            try {
+                lock.lock();
+                if (removeMe == null || contracts == null) return false;
+                return contracts.remove(removeMe);
+            } finally {
+                lock.unlock();
+            }
 	}
 
 	@Override
-	public synchronized String getImplementation() {
-		return implementation;
+	public String getImplementation() {
+            try {
+                lock.lock();
+                return implementation;
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
 	 * Sets the implementation
 	 * @param implementation The implementation this descriptor should have
 	 */
-    public synchronized void setImplementation(String implementation) {
-        this.implementation = implementation;
+    public void setImplementation(String implementation) {
+        try {
+            lock.lock();
+            this.implementation = implementation;
+        } finally {
+            lock.unlock();
+        }
     }
 
 	@Override
-	public synchronized String getScope() {
-		return scope;
+	public String getScope() {
+	    try {
+	        lock.lock();
+	        return scope;
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	/**
 	 * Sets the scope this descriptor should have
 	 * @param scope The scope of this descriptor
 	 */
-	public synchronized void setScope(String scope) {
-	    this.scope = scope;
+	public void setScope(String scope) {
+            try {
+                lock.lock();
+                this.scope = scope;
+            } finally {
+                lock.unlock();
+            }
 	}
 
 	@Override
-	public synchronized String getName() {
-		return name;
+	public String getName() {
+            try {
+                lock.lock();
+                return name;
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
 	 * Sets the name this descriptor should have
 	 * @param name The name for this descriptor
 	 */
-	public synchronized void setName(String name) {
-	    this.name = name;
+	public void setName(String name) {
+            try {
+                lock.lock();
+                this.name = name;
+            } finally {
+                lock.unlock();
+            }
 	}
 
 	@Override
-	public synchronized Set<String> getQualifiers() {
-	    if (qualifiers == null) return EMPTY_QUALIFIER_SET;
-		return Collections.unmodifiableSet(qualifiers);
+	public Set<String> getQualifiers() {
+            try {
+                lock.lock();
+                if (qualifiers == null) return EMPTY_QUALIFIER_SET;
+                return Collections.unmodifiableSet(qualifiers);
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
@@ -278,10 +330,15 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * 
 	 * @param addMe The fully qualified class name of the qualifier to add.  May not be null
 	 */
-	public synchronized void addQualifier(String addMe) {
-	    if (addMe == null) return;
-	    if (qualifiers == null) qualifiers = new LinkedHashSet<String>();
-	    qualifiers.add(addMe);
+	public void addQualifier(String addMe) {
+            try {
+                lock.lock();
+                if (addMe == null) return;
+                if (qualifiers == null) qualifiers = new LinkedHashSet<String>();
+                qualifiers.add(addMe);
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
@@ -290,44 +347,74 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param removeMe The fully qualifier class name of the qualifier to remove.  May not be null
 	 * @return true if the given qualifier was removed
 	 */
-	public synchronized boolean removeQualifier(String removeMe) {
-	    if (removeMe == null) return false;
-	    if (qualifiers == null) return false;
-	    return qualifiers.remove(removeMe);
+	public boolean removeQualifier(String removeMe) {
+            try {
+                lock.lock();
+                if (removeMe == null) return false;
+                if (qualifiers == null) return false;
+                return qualifiers.remove(removeMe);
+            } finally {
+                lock.unlock();
+            }
 	}
 
     @Override
-    public synchronized DescriptorType getDescriptorType() {
-        return descriptorType;
+    public DescriptorType getDescriptorType() {
+        try {
+            lock.lock();
+            return descriptorType;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Sets the descriptor type
      * @param descriptorType The descriptor type.  May not be null
      */
-    public synchronized void setDescriptorType(DescriptorType descriptorType) {
-        if (descriptorType == null) throw new IllegalArgumentException();
-        this.descriptorType = descriptorType;
+    public void setDescriptorType(DescriptorType descriptorType) {
+        try {
+            lock.lock();
+            if (descriptorType == null) throw new IllegalArgumentException();
+            this.descriptorType = descriptorType;
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override
-    public synchronized DescriptorVisibility getDescriptorVisibility() {
-        return descriptorVisibility;
+    public DescriptorVisibility getDescriptorVisibility() {
+        try {
+            lock.lock();
+            return descriptorVisibility;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Sets the descriptor visilibity
      * @param descriptorVisibility The visibility this descriptor should have
      */
-    public synchronized void setDescriptorVisibility(DescriptorVisibility descriptorVisibility) {
-        if (descriptorVisibility == null) throw new IllegalArgumentException();
-        this.descriptorVisibility = descriptorVisibility;
+    public void setDescriptorVisibility(DescriptorVisibility descriptorVisibility) {
+        try {
+            lock.lock();
+            if (descriptorVisibility == null) throw new IllegalArgumentException();
+            this.descriptorVisibility = descriptorVisibility;
+        } finally {
+            lock.unlock();
+        }
     }
 
 	@Override
-	public synchronized Map<String, List<String>> getMetadata() {
-	    if (metadatas == null) return EMPTY_METADATAS_MAP;
-		return Collections.unmodifiableMap(metadatas);
+	public Map<String, List<String>> getMetadata() {
+	    try {
+	        lock.lock();
+	        if (metadatas == null) return EMPTY_METADATAS_MAP;
+	            return Collections.unmodifiableMap(metadatas);
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	/**
@@ -339,15 +426,20 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param metadata The non-null metadata that this descriptor
 	 * should have
 	 */
-	public synchronized void setMetadata(Map<String, List<String>> metadata) {
-	    if (metadatas == null) {
-	        metadatas = new LinkedHashMap<String, List<String>>();
-	    }
-	    else {
-	        metadatas.clear();
-	    }
-	    
-	    metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+	public void setMetadata(Map<String, List<String>> metadata) {
+            try {
+                lock.lock();
+                if (metadatas == null) {
+                    metadatas = new LinkedHashMap<String, List<String>>();
+                }
+                else {
+                    metadatas.clear();
+                }
+                
+                metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
@@ -357,10 +449,15 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param metadata The non-null but possibly empty list of fields
 	 * to add to the metadata map
 	 */
-	public synchronized void addMetadata(Map<String, List<String>> metadata) {
-	    if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
-	    
-        metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+	public void addMetadata(Map<String, List<String>> metadata) {
+            try {
+                lock.lock();
+                if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
+                
+                metadatas.putAll(ReflectionHelper.deepCopyMetadata(metadata));
+            } finally {
+                lock.unlock();
+            }
     }
 	
 	/**
@@ -370,9 +467,14 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * not contain the character '='
 	 * @param value The value to add.  May not be null
 	 */
-	public synchronized void addMetadata(String key, String value) {
-	    if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
-	    ReflectionHelper.addMetadata(metadatas, key, value);
+	public void addMetadata(String key, String value) {
+            try {
+                lock.lock();
+                if (metadatas == null) metadatas = new LinkedHashMap<String, List<String>>();
+                ReflectionHelper.addMetadata(metadatas, key, value);
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
@@ -383,9 +485,14 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param value The value to remove.  May not be null
 	 * @return true if the value was removed
 	 */
-	public synchronized boolean removeMetadata(String key, String value) {
-	    if (metadatas == null) return false;
-	    return ReflectionHelper.removeMetadata(metadatas, key, value);
+	public boolean removeMetadata(String key, String value) {
+            try {
+                lock.lock();
+                if (metadatas == null) return false;
+                return ReflectionHelper.removeMetadata(metadatas, key, value);
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
@@ -394,60 +501,100 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	 * @param key The key of the metadata values to remove
 	 * @return true if any value was removed
 	 */
-	public synchronized boolean removeAllMetadata(String key) {
-	    if (metadatas == null) return false;
-	    return ReflectionHelper.removeAllMetadata(metadatas, key);
+	public boolean removeAllMetadata(String key) {
+            try {
+                lock.lock();
+                if (metadatas == null) return false;
+                return ReflectionHelper.removeAllMetadata(metadatas, key);
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	/**
      * Removes all metadata values
      */
-    public synchronized void clearMetadata() {
-        metadatas = null;
+    public void clearMetadata() {
+        try {
+            lock.lock();
+            metadatas = null;
+        } finally {
+            lock.unlock();
+        }
     }
 	
 	/* (non-Javadoc)
      * @see org.glassfish.hk2.api.Descriptor#getLoader()
      */
     @Override
-    public synchronized HK2Loader getLoader() {
-        return loader;
+    public HK2Loader getLoader() {
+        try {
+            lock.lock();
+            return loader;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
      * Sets the loader to use with this descriptor
      * @param loader The loader to use with this descriptor
      */
-    public synchronized void setLoader(HK2Loader loader) {
-        this.loader = loader;
+    public void setLoader(HK2Loader loader) {
+        try {
+            lock.lock();
+            this.loader = loader;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
-    public synchronized int getRanking() {
-        return rank;
+    public int getRanking() {
+        try {
+            lock.lock();
+            return rank;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /* (non-Javadoc)
      * @see org.glassfish.hk2.api.Descriptor#setRanking(int)
      */
     @Override
-    public synchronized int setRanking(int ranking) {
-        int retVal = rank;
-        rank = ranking;
-        return retVal;
+    public int setRanking(int ranking) {
+        try {
+            lock.lock();
+            int retVal = rank;
+            rank = ranking;
+            return retVal;
+        } finally {
+            lock.unlock();
+        }
     }
 	
 	@Override
-	public synchronized Long getServiceId() {
-		return id;
+	public Long getServiceId() {
+	        try {
+	            lock.lock();
+	            return id;
+	        } finally {
+	            lock.unlock();
+	        }
 	}
 	
 	/**
 	 * Sets the service id for this descriptor
 	 * @param id the service id for this descriptor
 	 */
-	public synchronized void setServiceId(Long id) {
-	    this.id = id;
+	public void setServiceId(Long id) {
+	    try {
+	        lock.lock();
+	        this.id = id;
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	@Override
@@ -501,16 +648,26 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	}
 	
 	@Override
-	public synchronized Long getLocatorId() {
-	    return locatorId;
+	public Long getLocatorId() {
+	    try {
+	        lock.lock();
+	        return locatorId;
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	/**
 	 * Sets the locator id for this descriptor
 	 * @param locatorId the locator id for this descriptor
 	 */
-	public synchronized void setLocatorId(Long locatorId) {
-	    this.locatorId = locatorId;
+	public void setLocatorId(Long locatorId) {
+            try {
+                lock.lock();
+                this.locatorId = locatorId;
+            } finally {
+                lock.unlock();
+            }
 	}
 	
 	public int hashCode() {
@@ -724,14 +881,19 @@ public class DescriptorImpl implements Descriptor, Externalizable {
 	    
 	}
 	
-	public synchronized String toString() {
-        StringBuffer sb = new StringBuffer("Descriptor(");
-        
-        pretty(sb, this);
-        
-        sb.append(")");
-        
-        return sb.toString();
+	public String toString() {
+	    try {
+	        lock.lock();
+    	            StringBuffer sb = new StringBuffer("Descriptor(");
+    	        
+    	            pretty(sb, this);
+    	        
+    	            sb.append(")");
+    	        
+    	            return sb.toString();
+	    } finally {
+	        lock.unlock();
+	    }
 	}
 	
 	/**

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/ImmediateContext.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/ImmediateContext.java
@@ -80,8 +80,8 @@ public class ImmediateContext implements Context<Immediate>{
             ServiceHandle<?> root) {
         U retVal = null;
         
+        lock.lock();
         try {
-            lock.lock();
             HandleAndService has = currentImmediateServices.get(activeDescriptor);
             if (has != null) {
                 return (U) has.getService();
@@ -118,8 +118,8 @@ public class ImmediateContext implements Context<Immediate>{
             retVal = activeDescriptor.create(root);
         }
         finally {
+            lock.lock();
             try {
-                lock.lock();
                 ServiceHandle<?> discoveredRoot = null;
                 if (root != null) {
                     if (root.getActiveDescriptor().equals(activeDescriptor)) {
@@ -148,8 +148,8 @@ public class ImmediateContext implements Context<Immediate>{
      */
     @Override
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             return currentImmediateServices.containsKey(descriptor);
         } finally {
             lock.unlock();
@@ -173,8 +173,8 @@ public class ImmediateContext implements Context<Immediate>{
             errorHandlers = locator.getAllServices(ImmediateErrorHandler.class);
         }
         
+        lock.lock();
         try {
-            lock.lock();
             HandleAndService has = currentImmediateServices.remove(descriptor);
             Object instance = has.getService();
         
@@ -215,8 +215,8 @@ public class ImmediateContext implements Context<Immediate>{
     public void shutdown() {
         List<ImmediateErrorHandler> errorHandlers = locator.getAllServices(ImmediateErrorHandler.class);
         
+        lock.lock();
         try {
-            lock.lock();
             for (Map.Entry<ActiveDescriptor<?>, HandleAndService> entry :
                 new HashSet<Map.Entry<ActiveDescriptor<?>, HandleAndService>>(currentImmediateServices.entrySet())) {
                 HandleAndService has = entry.getValue();
@@ -271,8 +271,8 @@ public class ImmediateContext implements Context<Immediate>{
         LinkedHashSet<ActiveDescriptor<?>> newFullSet = new LinkedHashSet<ActiveDescriptor<?>>(inScopeAndInThisLocator);
         LinkedHashSet<ActiveDescriptor<?>> addMe = new LinkedHashSet<ActiveDescriptor<?>>();
         
+        lock.lock();
         try {
-            lock.lock();
             // First thing to do is wait until all the things in-flight have gone
             while (creating.size() > 0) {
                 try {

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfigurationListener.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfigurationListener.java
@@ -330,8 +330,8 @@ public class ConfigurationListener implements BeanDatabaseUpdateListener {
         
         List<ActiveDescriptor<?>> progenitors = locator.getDescriptors(new NoNameTypeFilter(locator, null, null));
         
+        progenitorLock.lock();
         try {
-            progenitorLock.lock();
             allProgenitors.addAll(progenitors);
         } finally {
             progenitorLock.unlock();
@@ -527,8 +527,8 @@ public class ConfigurationListener implements BeanDatabaseUpdateListener {
         final DynamicConfiguration config = configurationService.createDynamicConfiguration();
         final LinkedList<ActiveDescriptor<?>> addedList = new LinkedList<ActiveDescriptor<?>>();
         final LinkedList<ActiveDescriptor<?>> removedList = new LinkedList<ActiveDescriptor<?>>();
+        progenitorLock.lock();
         try {
-            progenitorLock.lock();
             HashSet<ActiveDescriptor<?>> removed = new HashSet<ActiveDescriptor<?>>(allProgenitors);
             
             progenitors = locator.getDescriptors(new NoNameTypeFilter(locator, null, null));

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByContext.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -42,7 +43,7 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
 
     private final static ThreadLocal<ActiveDescriptor<?>> workingOn = ThreadLocal.withInitial(() -> null);
 
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private final Map<ActiveDescriptor<?>, Object> db = new HashMap<>();
 
     /* (non-Javadoc)
@@ -76,7 +77,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     @SuppressWarnings("unchecked")
     private <U> U internalFindOrCreate(ActiveDescriptor<U> activeDescriptor,
             ServiceHandle<?> root) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             U retVal = (U) db.get(activeDescriptor);
             if (retVal != null) return retVal;
 
@@ -88,6 +90,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
             db.put(activeDescriptor, retVal);
 
             return retVal;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -96,8 +100,11 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
      */
     @Override
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return db.containsKey(descriptor);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -107,11 +114,14 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     @SuppressWarnings("unchecked")
     @Override
     public void destroyOne(ActiveDescriptor<?> descriptor) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             Object destroyMe = db.remove(descriptor);
             if (destroyMe == null) return;
 
             ((ActiveDescriptor<Object>) descriptor).dispose(destroyMe);
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -137,11 +147,14 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
      */
     @Override
     public void shutdown() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             Set<ActiveDescriptor<?>> activeDescriptors = new HashSet<>(db.keySet());
             for (ActiveDescriptor<?> killMe : activeDescriptors) {
                 destroyOne(killMe);
             }
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -151,8 +164,11 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     }
 
     /* package */ Object findOnly(ActiveDescriptor<?> descriptor) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return db.get(descriptor);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByContext.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByContext.java
@@ -77,8 +77,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     @SuppressWarnings("unchecked")
     private <U> U internalFindOrCreate(ActiveDescriptor<U> activeDescriptor,
             ServiceHandle<?> root) {
+        lock.lock();
         try {
-            lock.lock();
             U retVal = (U) db.get(activeDescriptor);
             if (retVal != null) return retVal;
 
@@ -100,8 +100,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
      */
     @Override
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             return db.containsKey(descriptor);
         } finally {
             lock.unlock();
@@ -114,8 +114,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     @SuppressWarnings("unchecked")
     @Override
     public void destroyOne(ActiveDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             Object destroyMe = db.remove(descriptor);
             if (destroyMe == null) return;
 
@@ -147,8 +147,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
      */
     @Override
     public void shutdown() {
+        lock.lock();
         try {
-            lock.lock();
             Set<ActiveDescriptor<?>> activeDescriptors = new HashSet<>(db.keySet());
             for (ActiveDescriptor<?> killMe : activeDescriptors) {
                 destroyOne(killMe);
@@ -164,8 +164,8 @@ public class ConfiguredByContext implements Context<ConfiguredBy> {
     }
 
     /* package */ Object findOnly(ActiveDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             return db.get(descriptor);
         } finally {
             lock.unlock();

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByInjectionResolver.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/ConfiguredByInjectionResolver.java
@@ -98,8 +98,8 @@ public class ConfiguredByInjectionResolver implements
      */
     @Override
     public Object resolve(Injectee injectee, ServiceHandle<?> root) {
+        lock.lock();
         try {
-            lock.lock();
             ActiveDescriptor<?> injecteeParent = injectee.getInjecteeDescriptor();
             if (injecteeParent == null) return systemResolver.resolve(injectee, root);
             
@@ -153,8 +153,8 @@ public class ConfiguredByInjectionResolver implements
     }
     
     /* package */ BeanInfo addBean(ActiveDescriptor<?> descriptor, Object bean, String type, Object metadata) {
+        lock.lock();
         try {
-            lock.lock();
             BeanInfo retVal = new BeanInfo(type, descriptor.getName(), bean, metadata);
             beanMap.put(descriptor, retVal);
             return retVal;
@@ -165,8 +165,8 @@ public class ConfiguredByInjectionResolver implements
     
     /* package */ void removeBean(ActiveDescriptor<?> descriptor) {
         
+        lock.lock();
         try {
-            lock.lock();
             beanMap.remove(descriptor);
         } finally {
             lock.unlock();

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/DelegatingNamedActiveDescriptor.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/DelegatingNamedActiveDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Named;
 
@@ -187,7 +188,7 @@ public class DelegatingNamedActiveDescriptor implements
         return null;
     }
     
-    private Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private Object cache;
     private boolean isSet = false;
 
@@ -196,8 +197,11 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public Object getCache() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return cache;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -206,8 +210,11 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public boolean isCacheSet() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return isSet;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -216,9 +223,12 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public void setCache(Object cacheMe) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             isSet = true;
             cache = cacheMe;
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -228,9 +238,12 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public void releaseCache() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             cache = null;
             isSet = false;
+        } finally {
+            lock.unlock();
         }
 
     }

--- a/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/DelegatingNamedActiveDescriptor.java
+++ b/hk2-configuration/hk2-integration/src/main/java/org/glassfish/hk2/configuration/internal/DelegatingNamedActiveDescriptor.java
@@ -197,8 +197,8 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public Object getCache() {
+        lock.lock();
         try {
-            lock.lock();
             return cache;
         } finally {
             lock.unlock();
@@ -210,8 +210,8 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public boolean isCacheSet() {
+        lock.lock();
         try {
-            lock.lock();
             return isSet;
         } finally {
             lock.unlock();
@@ -223,8 +223,8 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public void setCache(Object cacheMe) {
+        lock.lock();
         try {
-            lock.lock();
             isSet = true;
             cache = cacheMe;
         } finally {
@@ -238,8 +238,8 @@ public class DelegatingNamedActiveDescriptor implements
      */
     @Override
     public void releaseCache() {
+        lock.lock();
         try {
-            lock.lock();
             cache = null;
             isSet = false;
         } finally {

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/BeanDatabaseImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/BeanDatabaseImpl.java
@@ -56,8 +56,8 @@ public class BeanDatabaseImpl implements BeanDatabase {
      */
     @Override
     public Set<Type> getAllTypes() {
+        lock.lock();
         try {
-            lock.lock();
             return Collections.unmodifiableSet(new HashSet<Type>(types.values()));
         } finally {
             lock.unlock();
@@ -69,8 +69,8 @@ public class BeanDatabaseImpl implements BeanDatabase {
      */
     @Override
     public Instance getInstance(String type, String instanceKey) {
+        lock.lock();
         try {
-            lock.lock();
             Type t = getType(type);
             if (t == null) return null;
 
@@ -85,8 +85,8 @@ public class BeanDatabaseImpl implements BeanDatabase {
      */
     @Override
     public Type getType(String type) {
+        lock.lock();
         try {
-            lock.lock();
             return types.get(type);
         } finally {
             lock.unlock();

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/HubImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/HubImpl.java
@@ -60,8 +60,8 @@ public class HubImpl implements Hub {
      */
     @Override
     public BeanDatabase getCurrentDatabase() {
+        lock.lock();
         try {
-            lock.lock();
             return currentDatabase;
         } finally {
             lock.unlock();
@@ -73,8 +73,8 @@ public class HubImpl implements Hub {
      */
     @Override
     public WriteableBeanDatabase getWriteableDatabaseCopy() {
+        lock.lock();
         try {
-            lock.lock();
             return new WriteableBeanDatabaseImpl(this, currentDatabase);
         } finally {
             lock.unlock();
@@ -84,8 +84,8 @@ public class HubImpl implements Hub {
     private int inTransaction = 0;
     
     /* package */ LinkedList<BeanDatabaseUpdateListener> prepareCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes) {
+        lock.lock();
         try {
-            lock.lock();
             if (inTransaction > 0) {
                 throw new IllegalStateException("This Hub is already in a transaction");
             }
@@ -130,8 +130,8 @@ public class HubImpl implements Hub {
     
     /* package */ void activateCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes,
             LinkedList<BeanDatabaseUpdateListener> completedListeners) {
+        lock.lock();
         try {
-            lock.lock();
             inTransaction--;
             if (inTransaction < 0) inTransaction = 0;
             
@@ -167,8 +167,8 @@ public class HubImpl implements Hub {
     
     /* package */ void rollbackCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes,
             LinkedList<BeanDatabaseUpdateListener> completedListeners) {
+        lock.lock();
         try {
-            lock.lock();
             inTransaction--;
             if (inTransaction < 0) inTransaction = 0;
             

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/HubImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/HubImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 
@@ -48,7 +49,7 @@ import org.jvnet.hk2.annotations.Service;
 public class HubImpl implements Hub {
     private static final AtomicLong revisionCounter = new AtomicLong(1);
     
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private BeanDatabaseImpl currentDatabase = new BeanDatabaseImpl(revisionCounter.getAndIncrement());
     
     @Inject
@@ -59,8 +60,11 @@ public class HubImpl implements Hub {
      */
     @Override
     public BeanDatabase getCurrentDatabase() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return currentDatabase;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -69,15 +73,19 @@ public class HubImpl implements Hub {
      */
     @Override
     public WriteableBeanDatabase getWriteableDatabaseCopy() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return new WriteableBeanDatabaseImpl(this, currentDatabase);
+        } finally {
+            lock.unlock();
         }
     }
     
     private int inTransaction = 0;
     
     /* package */ LinkedList<BeanDatabaseUpdateListener> prepareCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (inTransaction > 0) {
                 throw new IllegalStateException("This Hub is already in a transaction");
             }
@@ -115,12 +123,15 @@ public class HubImpl implements Hub {
             inTransaction++;
             
             return completedListeners;
+        } finally {
+            lock.unlock();
         }
     }
     
     /* package */ void activateCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes,
             LinkedList<BeanDatabaseUpdateListener> completedListeners) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             inTransaction--;
             if (inTransaction < 0) inTransaction = 0;
             
@@ -149,12 +160,15 @@ public class HubImpl implements Hub {
             }
             
             if (commitError != null) throw commitError;
+        } finally {
+            lock.unlock();
         }
     }
     
     /* package */ void rollbackCurrentDatabase(WriteableBeanDatabaseImpl writeableDatabase, Object commitMessage, List<Change> changes,
             LinkedList<BeanDatabaseUpdateListener> completedListeners) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             inTransaction--;
             if (inTransaction < 0) inTransaction = 0;
             
@@ -179,6 +193,8 @@ public class HubImpl implements Hub {
             }
             
             if (rollbackError != null) throw rollbackError;
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/InstanceImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/InstanceImpl.java
@@ -47,8 +47,8 @@ public class InstanceImpl implements Instance {
      */
     @Override
     public Object getMetadata() {
+        lock.lock();
         try {
-            lock.lock();
             return metadata;
         } finally {
             lock.unlock();

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/InstanceImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/InstanceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,8 @@
 
 package org.glassfish.hk2.configuration.hub.internal;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.glassfish.hk2.configuration.hub.api.Instance;
 
 /**
@@ -23,6 +25,7 @@ import org.glassfish.hk2.configuration.hub.api.Instance;
  *
  */
 public class InstanceImpl implements Instance {
+    private final ReentrantLock lock = new ReentrantLock();
     private final Object bean;
     private Object metadata;
     
@@ -43,8 +46,13 @@ public class InstanceImpl implements Instance {
      * @see org.glassfish.hk2.configuration.hub.api.Instance#getMetadata()
      */
     @Override
-    public synchronized Object getMetadata() {
-        return metadata;
+    public Object getMetadata() {
+        try {
+            lock.lock();
+            return metadata;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/TypeImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/TypeImpl.java
@@ -77,8 +77,8 @@ public class TypeImpl implements Type {
      */
     @Override
     public Object getMetadata() {
+        lock.lock();
         try {
-            lock.lock();
             return metadata;
         } finally {
             lock.unlock();
@@ -90,8 +90,8 @@ public class TypeImpl implements Type {
      */
     @Override
     public void setMetadata(Object metadata) {
+        lock.lock();
         try {
-            lock.lock();
             this.metadata = metadata;
         } finally {
             lock.unlock();

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/TypeImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/TypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.configuration.hub.internal;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.configuration.hub.api.Instance;
 import org.glassfish.hk2.configuration.hub.api.Type;
@@ -28,6 +29,7 @@ import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
  *
  */
 public class TypeImpl implements Type {
+    private final ReentrantLock lock = new ReentrantLock();
     private final String name;
     private final Map<String, Instance> instances;
     private final ClassReflectionHelper helper;
@@ -74,17 +76,26 @@ public class TypeImpl implements Type {
      * @see org.glassfish.hk2.configuration.hub.api.Type#getMetadata()
      */
     @Override
-    public synchronized Object getMetadata() {
-        return metadata;
+    public Object getMetadata() {
+        try {
+            lock.lock();
+            return metadata;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.configuration.hub.api.Type#setMetadata(java.lang.Object)
      */
     @Override
-    public synchronized void setMetadata(Object metadata) {
-        this.metadata = metadata;
-        
+    public void setMetadata(Object metadata) {
+        try {
+            lock.lock();
+            this.metadata = metadata;
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableBeanDatabaseImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableBeanDatabaseImpl.java
@@ -66,8 +66,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public Set<Type> getAllTypes() {
+        lock.lock();
         try {
-            lock.lock();
             return Collections.unmodifiableSet(new HashSet<Type>(types.values()));
         } finally {
             lock.unlock();
@@ -87,8 +87,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public Type getType(String type) {
+        lock.lock();
         try {
-            lock.lock();
             return types.get(type);
         } finally {
             lock.unlock();
@@ -100,8 +100,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public Instance getInstance(String type, String instanceKey) {
+        lock.lock();
         try {
-            lock.lock();
             Type t = getType(type);
             if (t == null) return null;
             
@@ -120,8 +120,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public WriteableType addType(String typeName) {
+        lock.lock();
         try {
-            lock.lock();
             if (typeName == null) throw new IllegalArgumentException();
             checkState();
             
@@ -147,8 +147,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public Type removeType(String typeName) {
+        lock.lock();
         try {
-            lock.lock();
             if (typeName == null) throw new IllegalArgumentException();
             checkState();
             
@@ -180,8 +180,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public WriteableType getWriteableType(String typeName) {
+        lock.lock();
         try {
-            lock.lock();
             checkState();
             return types.get(typeName);
         } finally {
@@ -194,8 +194,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public WriteableType findOrAddWriteableType(String typeName) {
+        lock.lock();
         try {
-            lock.lock();
             if (typeName == null) throw new IllegalArgumentException();
             checkState();
             
@@ -216,8 +216,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
     @Override
     public void commit() {
         Object defaultCommit;
+        lock.lock();
         try {
-            lock.lock();
             defaultCommit = commitMessage;
         } finally {
             lock.unlock();
@@ -231,8 +231,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public void commit(Object commitMessage) {
+        lock.lock();
         try {
-            lock.lock();
             checkState();
         
             committed = true;
@@ -255,8 +255,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
     }
     
     /* package */ void addChange(Change change) {
+        lock.lock();
         try {
-            lock.lock();
             changes.add(change);
         } finally {
             lock.unlock();
@@ -276,8 +276,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public void dumpDatabase(PrintStream output) {
+        lock.lock();
         try {
-            lock.lock();
             Utilities.dumpDatabase(this, output);
         } finally {
             lock.unlock();
@@ -305,8 +305,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public Object getCommitMessage() {
+        lock.lock();
         try {
-            lock.lock();
             return commitMessage;
         } finally {
             lock.unlock();
@@ -318,8 +318,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
      */
     @Override
     public void setCommitMessage(Object commitMessage) {
+        lock.lock();
         try {
-            lock.lock();
             this.commitMessage = commitMessage;
         } finally {
             lock.unlock();
@@ -339,8 +339,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
                 TwoPhaseTransactionData dynamicConfiguration)
                 throws MultiException {
             Object defaultCommit;
+            WriteableBeanDatabaseImpl.this.lock.lock();
             try {
-                WriteableBeanDatabaseImpl.this.lock.lock();
                 checkState();
                 
                 committed = true;
@@ -364,8 +364,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
             this.completedListeners = null;
             
             Object defaultCommit;
+            WriteableBeanDatabaseImpl.this.lock.lock();
             try {
-                WriteableBeanDatabaseImpl.this.lock.lock();
                 defaultCommit = commitMessage;
             } finally {
                 WriteableBeanDatabaseImpl.this.lock.unlock();
@@ -391,8 +391,8 @@ public class WriteableBeanDatabaseImpl implements WriteableBeanDatabase {
             this.completedListeners = null;
             
             Object defaultCommit;
+            WriteableBeanDatabaseImpl.this.lock.lock();
             try {
-                WriteableBeanDatabaseImpl.this.lock.lock();
                 defaultCommit = commitMessage;
             } finally {
                 WriteableBeanDatabaseImpl.this.lock.unlock();

--- a/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableTypeImpl.java
+++ b/hk2-configuration/manager/src/main/java/org/glassfish/hk2/configuration/hub/internal/WriteableTypeImpl.java
@@ -69,8 +69,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public Map<String, Instance> getInstances() {
+        lock.lock();
         try {
-            lock.lock();
             return Collections.unmodifiableMap(beanMap);
         } finally {
             lock.unlock();
@@ -82,8 +82,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public Instance getInstance(String key) {
+        lock.lock();
         try {
-            lock.lock();
             return beanMap.get(key);
         } finally {
             lock.unlock();
@@ -95,8 +95,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public Instance addInstance(String key, Object bean) {
+        lock.lock();
         try {
-            lock.lock();
             return addInstance(key, bean, null);
         } finally {
             lock.unlock();
@@ -108,8 +108,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public Instance addInstance(String key, Object bean, Object metadata) {
+        lock.lock();
         try {
-            lock.lock();
             if (key == null || bean == null) throw new IllegalArgumentException();
             
             InstanceImpl ii = new InstanceImpl(bean, metadata);
@@ -134,8 +134,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public Instance removeInstance(String key) {
+        lock.lock();
         try {
-            lock.lock();
             if (key == null) throw new IllegalArgumentException();
             
             Instance removedValue = beanMap.remove(key);
@@ -160,8 +160,8 @@ public class WriteableTypeImpl implements WriteableType {
     @Override
     public PropertyChangeEvent[] modifyInstance(String key, Object newBean,
             PropertyChangeEvent... propChanges) {
+        lock.lock();
         try {
-            lock.lock();
             if (key == null || newBean == null) throw new IllegalArgumentException();
             
             Instance oldInstance = beanMap.get(key);
@@ -204,8 +204,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public Object getMetadata() {
+        lock.lock();
         try {
-            lock.lock();
             return metadata;
         } finally {
             lock.unlock();
@@ -217,8 +217,8 @@ public class WriteableTypeImpl implements WriteableType {
      */
     @Override
     public void setMetadata(Object metadata) {
+        lock.lock();
         try {
-            lock.lock();
             this.metadata = metadata;
         } finally {
             lock.unlock();

--- a/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
+++ b/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
@@ -37,8 +37,8 @@ public class AbstractCountingListener implements BeanDatabaseUpdateListener {
     private int commitCalled;
     
     public int getNumPreparesCalled() {
+        lock.lock();
         try {
-            lock.lock();
             return prepareCalled;
         } finally {
             lock.unlock();
@@ -46,8 +46,8 @@ public class AbstractCountingListener implements BeanDatabaseUpdateListener {
     }
     
     public int getNumCommitsCalled() {
+        lock.lock();
         try {
-            lock.lock();
             return commitCalled;
         } finally {
             lock.unlock();
@@ -55,8 +55,8 @@ public class AbstractCountingListener implements BeanDatabaseUpdateListener {
     }
     
     public int getNumRollbackCalled() {
+        lock.lock();
         try {
-            lock.lock();
             return rollbackCalled;
         } finally {
             lock.unlock();
@@ -79,8 +79,8 @@ public class AbstractCountingListener implements BeanDatabaseUpdateListener {
     public void prepareDatabaseChange(BeanDatabase currentDatabase,
             BeanDatabase proposedDatabase, Object commitMessage,
             List<Change> changes) {
+        lock.lock();
         try {
-            lock.lock();
             prepareCalled++;
             prepareAction();
         } finally {

--- a/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
+++ b/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
+++ b/hk2-configuration/manager/src/test/java/org/glassfish/hk2/configuration/hub/test/AbstractCountingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.hk2.configuration.hub.test;
 
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -30,20 +31,36 @@ import org.glassfish.hk2.configuration.hub.api.Change;
  */
 @Singleton
 public class AbstractCountingListener implements BeanDatabaseUpdateListener {
+    private final ReentrantLock lock = new ReentrantLock();
     private int prepareCalled;
     private int rollbackCalled;
     private int commitCalled;
     
-    public synchronized int getNumPreparesCalled() {
-        return prepareCalled;
+    public int getNumPreparesCalled() {
+        try {
+            lock.lock();
+            return prepareCalled;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    public synchronized int getNumCommitsCalled() {
-        return commitCalled;
+    public int getNumCommitsCalled() {
+        try {
+            lock.lock();
+            return commitCalled;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    public synchronized int getNumRollbackCalled() {
-        return rollbackCalled;
+    public int getNumRollbackCalled() {
+        try {
+            lock.lock();
+            return rollbackCalled;
+        } finally {
+            lock.unlock();
+        }
     }
     
     public void prepareAction() {
@@ -59,11 +76,16 @@ public class AbstractCountingListener implements BeanDatabaseUpdateListener {
      * @see org.glassfish.hk2.configuration.hub.api.BeanDatabaseUpdateListener#prepareDatabaseChange(org.glassfish.hk2.configuration.hub.api.BeanDatabase, org.glassfish.hk2.configuration.hub.api.BeanDatabase, java.lang.Object, java.util.List)
      */
     @Override
-    public synchronized void prepareDatabaseChange(BeanDatabase currentDatabase,
+    public void prepareDatabaseChange(BeanDatabase currentDatabase,
             BeanDatabase proposedDatabase, Object commitMessage,
             List<Change> changes) {
-        prepareCalled++;
-        prepareAction();
+        try {
+            lock.lock();
+            prepareCalled++;
+            prepareAction();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBufParser.java
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBufParser.java
@@ -404,8 +404,8 @@ public class PBufParser implements XmlServiceParser {
         String protoName = getSimpleName(originalInterface);
         
         Descriptors.Descriptor descriptor;
+        lockProtos.lock();
         try {
-            lockProtos.lock();
             descriptor = allProtos.get(originalAsClass);
         } finally {
             lockProtos.unlock();
@@ -430,8 +430,8 @@ public class PBufParser implements XmlServiceParser {
         String protoName = getSimpleName(originalInterface);
         
         Descriptors.Descriptor descriptor;
+        lockProtos.lock();
         try {
-            lockProtos.lock();
             descriptor = allProtos.get(originalAsClass);
         } finally {
             lockProtos.unlock();
@@ -524,8 +524,8 @@ public class PBufParser implements XmlServiceParser {
     }
     
     private void convertAllModels(ModelImpl model, Set<Descriptors.FileDescriptor> protoFiles) throws Exception {
+        lockProtos.lock();
         try {
-            lockProtos.lock();
             Class<?> modelClass = model.getOriginalInterfaceAsClass();
             Descriptors.Descriptor dd = allProtos.get(modelClass);
             if (dd != null) {
@@ -836,8 +836,8 @@ public class PBufParser implements XmlServiceParser {
     
     private String convertEnumToDescriptor(ChildDataModel childDataModel,
             Set<Descriptors.FileDescriptor> knownFiles) throws Exception {
+        lockEnums.lock();
         try {
-            lockEnums.lock();
             Class<?> expectedType = childDataModel.getChildTypeAsClass();
             if (allEnums.containsKey(expectedType)) {
                 return "." + expectedType.getName();
@@ -897,8 +897,8 @@ public class PBufParser implements XmlServiceParser {
         
         if (expectedType.isEnum()) {
             Descriptors.EnumDescriptor enumDescriptor;
+            lockEnums.lock();
             try {
-                lockEnums.lock();
                 enumDescriptor = allEnums.get(expectedType);
             } finally {
                 lockEnums.unlock();
@@ -941,8 +941,8 @@ public class PBufParser implements XmlServiceParser {
         
         if (expectedType.isEnum()) {
             Descriptors.EnumDescriptor enumDescriptor;
+            lockEnums.lock();
             try {
-                lockEnums.lock();
                 enumDescriptor = allEnums.get(expectedType);
             } finally {
                 lockEnums.unlock();

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBufParser.java
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/src/main/java/org/glassfish/hk2/pbuf/internal/PBufParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -75,6 +76,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 @Named(PBufUtilities.PBUF_SERVICE_NAME)
 @Visibility(DescriptorVisibility.LOCAL)
 public class PBufParser implements XmlServiceParser {
+    private final ReentrantLock lockProtos = new ReentrantLock();
+    private final ReentrantLock lockEnums = new ReentrantLock();
     private final HashMap<Class<?>, Descriptors.Descriptor> allProtos = new HashMap<Class<?>, Descriptors.Descriptor>();
     private final HashMap<Class<?>, Descriptors.EnumDescriptor> allEnums = new HashMap<Class<?>, Descriptors.EnumDescriptor>();
     
@@ -401,8 +404,11 @@ public class PBufParser implements XmlServiceParser {
         String protoName = getSimpleName(originalInterface);
         
         Descriptors.Descriptor descriptor;
-        synchronized (allProtos) {
+        try {
+            lockProtos.lock();
             descriptor = allProtos.get(originalAsClass);
+        } finally {
+            lockProtos.unlock();
         }
         if (descriptor == null) {
             throw new IOException("Unknown model: " + originalInterface + " with protoName=" + protoName);
@@ -424,8 +430,11 @@ public class PBufParser implements XmlServiceParser {
         String protoName = getSimpleName(originalInterface);
         
         Descriptors.Descriptor descriptor;
-        synchronized (allProtos) {
+        try {
+            lockProtos.lock();
             descriptor = allProtos.get(originalAsClass);
+        } finally {
+            lockProtos.unlock();
         }
         
         if (descriptor == null) {
@@ -515,7 +524,8 @@ public class PBufParser implements XmlServiceParser {
     }
     
     private void convertAllModels(ModelImpl model, Set<Descriptors.FileDescriptor> protoFiles) throws Exception {
-        synchronized (allProtos) {
+        try {
+            lockProtos.lock();
             Class<?> modelClass = model.getOriginalInterfaceAsClass();
             Descriptors.Descriptor dd = allProtos.get(modelClass);
             if (dd != null) {
@@ -538,6 +548,8 @@ public class PBufParser implements XmlServiceParser {
             protoFiles.add(converted.getFile());
         
             allProtos.put(modelClass, converted);
+        } finally {
+            lockProtos.unlock();
         }
     }
     
@@ -824,7 +836,8 @@ public class PBufParser implements XmlServiceParser {
     
     private String convertEnumToDescriptor(ChildDataModel childDataModel,
             Set<Descriptors.FileDescriptor> knownFiles) throws Exception {
-        synchronized (allEnums) {
+        try {
+            lockEnums.lock();
             Class<?> expectedType = childDataModel.getChildTypeAsClass();
             if (allEnums.containsKey(expectedType)) {
                 return "." + expectedType.getName();
@@ -868,6 +881,8 @@ public class PBufParser implements XmlServiceParser {
             allEnums.put(expectedType, fD);
         
             return "." + enumTypeName;
+        } finally {
+            lockEnums.unlock();
         }
     }
     
@@ -882,8 +897,11 @@ public class PBufParser implements XmlServiceParser {
         
         if (expectedType.isEnum()) {
             Descriptors.EnumDescriptor enumDescriptor;
-            synchronized (allEnums) {
+            try {
+                lockEnums.lock();
                 enumDescriptor = allEnums.get(expectedType);
+            } finally {
+                lockEnums.unlock();
             }
             
             if (enumDescriptor == null) {
@@ -923,8 +941,11 @@ public class PBufParser implements XmlServiceParser {
         
         if (expectedType.isEnum()) {
             Descriptors.EnumDescriptor enumDescriptor;
-            synchronized (allEnums) {
+            try {
+                lockEnums.lock();
                 enumDescriptor = allEnums.get(expectedType);
+            } finally {
+                lockEnums.unlock();
             }
             
             if (enumDescriptor == null) {

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.hk2.xml.internal;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.general.GeneralUtilities;
 
@@ -44,7 +45,7 @@ public class ChildDataModel implements Serializable {
         TYPE_MAP.put("boolean", boolean.class);
     };
     
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     
     /** Set at compile time, the type of the thing */
     private String childType;
@@ -113,13 +114,17 @@ public class ChildDataModel implements Serializable {
     }
     
     public void setLoader(ClassLoader myLoader) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             this.myLoader = myLoader;
+        } finally {
+            lock.unlock();
         }
     }
     
     public Class<?> getChildTypeAsClass() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (childTypeAsClass != null) return childTypeAsClass;
             
             childTypeAsClass = TYPE_MAP.get(childType);
@@ -128,12 +133,15 @@ public class ChildDataModel implements Serializable {
             childTypeAsClass = GeneralUtilities.loadClass(myLoader, childType);
             
             return childTypeAsClass;
+        } finally {
+            lock.unlock();
         }
         
     }
     
     public Class<?> getChildListTypeAsClass() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (childListType == null) return null;
             if (childListTypeAsClass != null) return childListTypeAsClass;
             
@@ -143,6 +151,8 @@ public class ChildDataModel implements Serializable {
             childListTypeAsClass = GeneralUtilities.loadClass(myLoader, childListType);
             
             return childListTypeAsClass;
+        } finally {
+            lock.unlock();
         }
         
     }

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
@@ -114,8 +114,8 @@ public class ChildDataModel implements Serializable {
     }
     
     public void setLoader(ClassLoader myLoader) {
+        lock.lock();
         try {
-            lock.lock();
             this.myLoader = myLoader;
         } finally {
             lock.unlock();
@@ -123,8 +123,8 @@ public class ChildDataModel implements Serializable {
     }
     
     public Class<?> getChildTypeAsClass() {
+        lock.lock();
         try {
-            lock.lock();
             if (childTypeAsClass != null) return childTypeAsClass;
             
             childTypeAsClass = TYPE_MAP.get(childType);
@@ -140,8 +140,8 @@ public class ChildDataModel implements Serializable {
     }
     
     public Class<?> getChildListTypeAsClass() {
+        lock.lock();
         try {
-            lock.lock();
             if (childListType == null) return null;
             if (childListTypeAsClass != null) return childListTypeAsClass;
             

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ChildDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
@@ -146,8 +146,8 @@ public class JAUtilities {
     }
     
     public void convertRootAndLeaves(Class<?> root, boolean mustConvertAll) {
+        lock.lock();
         try {
-            lock.lock();
             long currentTime = 0L;
             if (DEBUG_GENERATION_TIMING) {
                 computer.numGenerated = 0;

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/JAUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -74,7 +75,8 @@ public class JAUtilities {
     public final static String REMOVE = "remove";
     public final static String JAXB_DEFAULT_STRING = "##default";
     public final static String JAXB_DEFAULT_DEFAULT = "\u0000";
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ClassReflectionHelper classReflectionHelper;
     private final ClassPool defaultClassPool;
     private final CtClass superClazz;
@@ -143,38 +145,43 @@ public class JAUtilities {
         return entry.getValue();
     }
     
-    public synchronized void convertRootAndLeaves(Class<?> root, boolean mustConvertAll) {
-        long currentTime = 0L;
-        if (DEBUG_GENERATION_TIMING) {
-            computer.numGenerated = 0;
-            computer.numPreGenerated = 0;
+    public void convertRootAndLeaves(Class<?> root, boolean mustConvertAll) {
+        try {
+            lock.lock();
+            long currentTime = 0L;
+            if (DEBUG_GENERATION_TIMING) {
+                computer.numGenerated = 0;
+                computer.numPreGenerated = 0;
+                
+                currentTime = System.currentTimeMillis();
+            }
             
-            currentTime = System.currentTimeMillis();
-        }
-        
-        ModelImpl rootModel = interface2ModelCache.compute(root).getValue();
-        if (!mustConvertAll) {
+            ModelImpl rootModel = interface2ModelCache.compute(root).getValue();
+            if (!mustConvertAll) {
+                if (DEBUG_GENERATION_TIMING) {
+                    currentTime = System.currentTimeMillis() - currentTime;
+                    
+                    Logger.getLogger().debug("Took " + currentTime + " to perform " +
+                      computer.numGenerated + " generations with " +
+                      computer.numPreGenerated + " pre generated with a lazy parser");
+                }
+                return;
+            }
+            
+            HashSet<Class<?>> cycles = new HashSet<Class<?>>();
+            cycles.add(root);
+            
+            convertAllRootAndLeaves(rootModel, cycles);
+            
             if (DEBUG_GENERATION_TIMING) {
                 currentTime = System.currentTimeMillis() - currentTime;
                 
-                Logger.getLogger().debug("Took " + currentTime + " to perform " +
+                Logger.getLogger().debug("Took " + currentTime + " milliseconds to perform " +
                   computer.numGenerated + " generations with " +
-                  computer.numPreGenerated + " pre generated with a lazy parser");
+                  computer.numPreGenerated + " pre generated with a non-lazy parser");
             }
-            return;
-        }
-        
-        HashSet<Class<?>> cycles = new HashSet<Class<?>>();
-        cycles.add(root);
-        
-        convertAllRootAndLeaves(rootModel, cycles);
-        
-        if (DEBUG_GENERATION_TIMING) {
-            currentTime = System.currentTimeMillis() - currentTime;
-            
-            Logger.getLogger().debug("Took " + currentTime + " milliseconds to perform " +
-              computer.numGenerated + " generations with " +
-              computer.numPreGenerated + " pre generated with a non-lazy parser");
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ModelImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ModelImpl.java
@@ -264,8 +264,8 @@ public class ModelImpl implements Model {
     }
     
     public Set<String> getAllXmlWrappers() {
+        slock.lock();
         try {
-            slock.lock();
             if (allXmlWrappers != null) return allXmlWrappers;
             allXmlWrappers = new LinkedHashSet<String>();
             
@@ -286,8 +286,8 @@ public class ModelImpl implements Model {
     }
     
     public Set<QName> getUnKeyedChildren() {
+        slock.lock();
         try {
-            slock.lock();
             if (unKeyedChildren != null) return unKeyedChildren;
             
             unKeyedChildren = new HashSet<QName>();
@@ -304,8 +304,8 @@ public class ModelImpl implements Model {
     }
     
     public Set<QName> getKeyedChildren() {
+        slock.lock();
         try {
-            slock.lock();
             if (keyedChildren != null) return keyedChildren;
             
             keyedChildren = new HashSet<QName>();
@@ -322,8 +322,8 @@ public class ModelImpl implements Model {
     }
     
     public void setJAUtilities(JAUtilities jaUtilities, ClassLoader myLoader) {
+        slock.lock();
         try {
-            slock.lock();
             if (this.jaUtilities != null) return;
             this.jaUtilities = jaUtilities;
             this.myLoader = myLoader;
@@ -343,8 +343,8 @@ public class ModelImpl implements Model {
     public String getDefaultChildValue(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
+        slock.lock();
         try {
-            slock.lock();
             ChildDataModel cd = nonChildProperty.get(propQName);
             if (cd == null) return null;
             return cd.getDefaultAsString();
@@ -356,8 +356,8 @@ public class ModelImpl implements Model {
     public ModelPropertyType getModelPropertyType(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
+        slock.lock();
         try {
-            slock.lock();
             if (nonChildProperty.containsKey(propQName)) return ModelPropertyType.FLAT_PROPERTY;
             if (childrenByName.containsKey(propQName)) return ModelPropertyType.TREE_ROOT;
             
@@ -370,8 +370,8 @@ public class ModelImpl implements Model {
     public Class<?> getNonChildType(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
+        slock.lock();
         try {
-            slock.lock();
             ChildDataModel cd = nonChildProperty.get(propQName);
             if (cd == null) return null;
             
@@ -384,8 +384,8 @@ public class ModelImpl implements Model {
     public ParentedModel getChild(String propNamespace, String propName) {
         QName propQName = QNameUtilities.createQName(propNamespace, propName);
         
+        slock.lock();
         try {
-            slock.lock();
             return childrenByName.get(propQName);
         } finally {
             slock.unlock();
@@ -396,8 +396,8 @@ public class ModelImpl implements Model {
     public Class<?> getOriginalInterfaceAsClass() {
         if (originalInterfaceAsClass != null) return originalInterfaceAsClass;
         
+        slock.lock();
         try {
-            slock.lock();
             if (originalInterfaceAsClass != null) return originalInterfaceAsClass;
             
             originalInterfaceAsClass = GeneralUtilities.loadClass(myLoader, originalInterface);
@@ -412,8 +412,8 @@ public class ModelImpl implements Model {
     public Class<?> getProxyAsClass() {
         if (translatedClassAsClass != null) return translatedClassAsClass;
         
+        slock.lock();
         try {
-            slock.lock();
             if (translatedClassAsClass != null) return translatedClassAsClass;
             
             translatedClassAsClass = GeneralUtilities.loadClass(myLoader, translatedClass);
@@ -425,8 +425,8 @@ public class ModelImpl implements Model {
     }
     
     public Collection<ParentedModel> getAllChildren() {
+        slock.lock();
         try {
-            slock.lock();
             return Collections.unmodifiableCollection(childrenByName.values());
         } finally {
             slock.unlock();
@@ -434,8 +434,8 @@ public class ModelImpl implements Model {
     }
     
     public Map<QName, ParentedModel> getChildrenProperties() {
+        slock.lock();
         try {
-            slock.lock();
             return Collections.unmodifiableMap(childrenByName);
         } finally {
             slock.unlock();
@@ -481,8 +481,8 @@ public class ModelImpl implements Model {
     }
     
     public String getJavaNameFromKey(String key, ClassReflectionHelper reflectionHelper) {
+        lock.lock();
         try {
-            lock.lock();
             if (keyToJavaNameMap == null) {
                 keyToJavaNameMap = new LinkedHashMap<String, String>();
             }

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ParentedModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ParentedModel.java
@@ -127,8 +127,8 @@ public class ParentedModel implements Serializable {
     
     @SuppressWarnings("unchecked")
     public XmlAdapter<?, ?> getAdapterObject() {
+        lock.lock();
         try {
-            lock.lock();
             if (myLoader == null) {
                 throw new IllegalStateException("Cannot call getChildModel before the classloader has been determined");
             }
@@ -158,8 +158,8 @@ public class ParentedModel implements Serializable {
     }
     
     public ModelImpl getChildModel() {
+        lock.lock();
         try {
-            lock.lock();
             if (myLoader == null) {
                 throw new IllegalStateException("Cannot call getChildModel before the classloader has been determined");
             }
@@ -185,8 +185,8 @@ public class ParentedModel implements Serializable {
     }
     
     public void setRuntimeInformation(JAUtilities jaUtilities, ClassLoader myLoader) {
+        lock.lock();
         try {
-            lock.lock();
             this.jaUtilities = jaUtilities;
             this.myLoader = myLoader;
         } finally {

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ParentedModel.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/ParentedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.hk2.xml.internal;
 
 import java.io.Serializable;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
@@ -34,8 +35,8 @@ import org.glassfish.hk2.utilities.general.GeneralUtilities;
  */
 public class ParentedModel implements Serializable {
     private static final long serialVersionUID = -2480798409414987937L;
-    
-    private final Object lock = new Object();
+
+    private final ReentrantLock lock = new ReentrantLock();
     
     /** The interface of the child for which this is a parent */
     private String childInterface;
@@ -126,7 +127,8 @@ public class ParentedModel implements Serializable {
     
     @SuppressWarnings("unchecked")
     public XmlAdapter<?, ?> getAdapterObject() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (myLoader == null) {
                 throw new IllegalStateException("Cannot call getChildModel before the classloader has been determined");
             }
@@ -149,12 +151,15 @@ public class ParentedModel implements Serializable {
             catch (Exception e) {
                 throw new RuntimeException(e);
             }
+        } finally {
+            lock.unlock();
         }
         
     }
     
     public ModelImpl getChildModel() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (myLoader == null) {
                 throw new IllegalStateException("Cannot call getChildModel before the classloader has been determined");
             }
@@ -174,13 +179,18 @@ public class ParentedModel implements Serializable {
             }
             
             return childModel;
+        } finally {
+            lock.unlock();
         }
     }
     
     public void setRuntimeInformation(JAUtilities jaUtilities, ClassLoader myLoader) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             this.jaUtilities = jaUtilities;
             this.myLoader = myLoader;
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/UnkeyedDiff.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/UnkeyedDiff.java
@@ -93,8 +93,8 @@ public class UnkeyedDiff {
     }
     
     public Differences compute() {
+        lock.lock();
         try {
-            lock.lock();
             if (computed) return finalSolution;
             
             Differences retVal = null;

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/AnnotationAltAnnotationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/AnnotationAltAnnotationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
 import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
@@ -44,7 +45,8 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
         DO_NOT_HANDLE_METHODS.add("toString");
         DO_NOT_HANDLE_METHODS.add("annotationType");
     }
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final Annotation annotation;
     private final ClassReflectionHelper helper;
     private Map<String, Object> values;
@@ -75,33 +77,48 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getStringValue(java.lang.String)
      */
     @Override
-    public synchronized String getStringValue(String methodName) {
-        if (values == null) getAnnotationValues();
-        
-        if (XmlElementImpl.class.equals(annotation.getClass()) &&
-                "getTypeByName".equals(methodName)) {
-            XmlElementImpl xei = (XmlElementImpl) annotation;
-            return xei.getTypeByName();
+    public String getStringValue(String methodName) {
+        try {
+            lock.lock();
+            if (values == null) getAnnotationValues();
+            
+            if (XmlElementImpl.class.equals(annotation.getClass()) &&
+                    "getTypeByName".equals(methodName)) {
+                XmlElementImpl xei = (XmlElementImpl) annotation;
+                return xei.getTypeByName();
+            }
+            
+            return (String) values.get(methodName);
+        } finally {
+            lock.unlock();
         }
-        
-        return (String) values.get(methodName);
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getBooleanValue(java.lang.String)
      */
     @Override
-    public synchronized boolean getBooleanValue(String methodName) {
-        if (values == null) getAnnotationValues();
-        
-        return (Boolean) values.get(methodName);
+    public boolean getBooleanValue(String methodName) {
+        try {
+            lock.lock();
+            if (values == null) getAnnotationValues();
+            
+            return (Boolean) values.get(methodName);
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override
-    public synchronized String[] getStringArrayValue(String methodName) {
-        if (values == null) getAnnotationValues();
-        
-        return (String[]) values.get(methodName);
+    public String[] getStringArrayValue(String methodName) {
+        try {
+            lock.lock();
+            if (values == null) getAnnotationValues();
+            
+            return (String[]) values.get(methodName);
+        } finally {
+            lock.unlock();
+        }
     }
     
     @Override
@@ -122,76 +139,81 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getAnnotationValues()
      */
     @Override
-    public synchronized Map<String, Object> getAnnotationValues() {
-        if (values != null) return values;
-        
-        Map<String, Object> retVal = new TreeMap<String, Object>();
-        for (Method javaAnnotationMethod : annotation.annotationType().getMethods()) {
-            if (javaAnnotationMethod.getParameterTypes().length != 0) continue;
-            if (DO_NOT_HANDLE_METHODS.contains(javaAnnotationMethod.getName())) continue;
+    public Map<String, Object> getAnnotationValues() {
+        try {
+            lock.lock();
+            if (values != null) return values;
             
-            String key = javaAnnotationMethod.getName();
-            
-            Object value;
-            try {
-                value = ReflectionHelper.invoke(annotation, javaAnnotationMethod, new Object[0], false);
+            Map<String, Object> retVal = new TreeMap<String, Object>();
+            for (Method javaAnnotationMethod : annotation.annotationType().getMethods()) {
+                if (javaAnnotationMethod.getParameterTypes().length != 0) continue;
+                if (DO_NOT_HANDLE_METHODS.contains(javaAnnotationMethod.getName())) continue;
                 
-                if (value == null) {
-                    throw new AssertionError("Recieved null from annotation method " + javaAnnotationMethod.getName());
+                String key = javaAnnotationMethod.getName();
+                
+                Object value;
+                try {
+                    value = ReflectionHelper.invoke(annotation, javaAnnotationMethod, new Object[0], false);
+                    
+                    if (value == null) {
+                        throw new AssertionError("Recieved null from annotation method " + javaAnnotationMethod.getName());
+                    }
                 }
-            }
-            catch (RuntimeException re) {
-                throw re;
-            }
-            catch (Throwable th) {
-                throw new RuntimeException(th);
-            }
-            
-            if (value instanceof Class) {
-                value = new ClassAltClassImpl((Class<?>) value, helper);
-            }
-            else if (Enum.class.isAssignableFrom(value.getClass())) {
-                value = new EnumAltEnumImpl((Enum<?>) value);
-            }
-            else if (value.getClass().isArray() && Class.class.equals(value.getClass().getComponentType())) {
-                Class<?> cValue[] = (Class<?>[]) value;
-                
-                AltClass[] translatedValue = new AltClass[cValue.length];
-                
-                for (int lcv = 0; lcv < cValue.length; lcv++) {
-                    translatedValue[lcv] = new ClassAltClassImpl(cValue[lcv], helper);
+                catch (RuntimeException re) {
+                    throw re;
+                }
+                catch (Throwable th) {
+                    throw new RuntimeException(th);
                 }
                 
-                value = translatedValue;
-            }
-            else if (value.getClass().isArray() && Enum.class.isAssignableFrom(value.getClass().getComponentType())) {
-                Enum<?> eValue[] = (Enum<?>[]) value;
-                
-                AltEnum[] translatedValue = new AltEnum[eValue.length];
-                
-                for (int lcv = 0; lcv < eValue.length; lcv++) {
-                    translatedValue[lcv] = new EnumAltEnumImpl(eValue[lcv]);
+                if (value instanceof Class) {
+                    value = new ClassAltClassImpl((Class<?>) value, helper);
+                }
+                else if (Enum.class.isAssignableFrom(value.getClass())) {
+                    value = new EnumAltEnumImpl((Enum<?>) value);
+                }
+                else if (value.getClass().isArray() && Class.class.equals(value.getClass().getComponentType())) {
+                    Class<?> cValue[] = (Class<?>[]) value;
+                    
+                    AltClass[] translatedValue = new AltClass[cValue.length];
+                    
+                    for (int lcv = 0; lcv < cValue.length; lcv++) {
+                        translatedValue[lcv] = new ClassAltClassImpl(cValue[lcv], helper);
+                    }
+                    
+                    value = translatedValue;
+                }
+                else if (value.getClass().isArray() && Enum.class.isAssignableFrom(value.getClass().getComponentType())) {
+                    Enum<?> eValue[] = (Enum<?>[]) value;
+                    
+                    AltEnum[] translatedValue = new AltEnum[eValue.length];
+                    
+                    for (int lcv = 0; lcv < eValue.length; lcv++) {
+                        translatedValue[lcv] = new EnumAltEnumImpl(eValue[lcv]);
+                    }
+                    
+                    value = translatedValue;
+                }
+                else if (value.getClass().isArray() && Annotation.class.isAssignableFrom(value.getClass().getComponentType())) {
+                    Annotation aValue[] = (Annotation[]) value;
+                    
+                    AltAnnotation[] translatedValue = new AltAnnotation[aValue.length];
+                    
+                    for (int lcv = 0; lcv < aValue.length; lcv++) {
+                        translatedValue[lcv] = new AnnotationAltAnnotationImpl(aValue[lcv], helper);
+                    }
+                    
+                    value = translatedValue;
                 }
                 
-                value = translatedValue;
-            }
-            else if (value.getClass().isArray() && Annotation.class.isAssignableFrom(value.getClass().getComponentType())) {
-                Annotation aValue[] = (Annotation[]) value;
-                
-                AltAnnotation[] translatedValue = new AltAnnotation[aValue.length];
-                
-                for (int lcv = 0; lcv < aValue.length; lcv++) {
-                    translatedValue[lcv] = new AnnotationAltAnnotationImpl(aValue[lcv], helper);
-                }
-                
-                value = translatedValue;
+                retVal.put(key, value);
             }
             
-            retVal.put(key, value);
+            values = Collections.unmodifiableMap(retVal);
+            return values;
+        } finally {
+            lock.unlock();
         }
-        
-        values = Collections.unmodifiableMap(retVal);
-        return values;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/AnnotationAltAnnotationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/AnnotationAltAnnotationImpl.java
@@ -78,8 +78,8 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      */
     @Override
     public String getStringValue(String methodName) {
+        lock.lock();
         try {
-            lock.lock();
             if (values == null) getAnnotationValues();
             
             if (XmlElementImpl.class.equals(annotation.getClass()) &&
@@ -99,8 +99,8 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      */
     @Override
     public boolean getBooleanValue(String methodName) {
+        lock.lock();
         try {
-            lock.lock();
             if (values == null) getAnnotationValues();
             
             return (Boolean) values.get(methodName);
@@ -111,8 +111,8 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
     
     @Override
     public String[] getStringArrayValue(String methodName) {
+        lock.lock();
         try {
-            lock.lock();
             if (values == null) getAnnotationValues();
             
             return (String[]) values.get(methodName);
@@ -140,8 +140,8 @@ public class AnnotationAltAnnotationImpl implements AltAnnotation {
      */
     @Override
     public Map<String, Object> getAnnotationValues() {
+        lock.lock();
         try {
-            lock.lock();
             if (values != null) return values;
             
             Map<String, Object> retVal = new TreeMap<String, Object>();

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/ClassAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/ClassAltClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
@@ -51,7 +52,8 @@ public class ClassAltClassImpl implements AltClass {
     public static final AltClass DOUBLE = new ClassAltClassImpl(double.class, SCALAR_HELPER);
     public static final AltClass OBJECT = new ClassAltClassImpl(Object.class, SCALAR_HELPER);
     public static final AltClass XML_ADAPTER = new ClassAltClassImpl(XmlAdapter.class, SCALAR_HELPER);
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final Class<?> clazz;
     private final ClassReflectionHelper helper;
     private List<AltMethod> methods;
@@ -86,36 +88,46 @@ public class ClassAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (annotations != null) return annotations;
-        
-        Annotation annotationz[] = clazz.getAnnotations();
-        
-        ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotationz.length);
-        for (Annotation annotation : annotationz) {
-            retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+    public List<AltAnnotation> getAnnotations() {
+        try {
+            lock.lock();
+            if (annotations != null) return annotations;
+            
+            Annotation annotationz[] = clazz.getAnnotations();
+            
+            ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotationz.length);
+            for (Annotation annotation : annotationz) {
+                retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+            }
+            
+            annotations = Collections.unmodifiableList(retVal);
+            return annotations;
+        } finally {
+            lock.unlock();
         }
-        
-        annotations = Collections.unmodifiableList(retVal);
-        return annotations;
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getMethods()
      */
     @Override
-    public synchronized List<AltMethod> getMethods() {
-        if (methods != null) return methods;
-        
-        Set<MethodWrapper> wrappers = helper.getAllMethods(clazz);
-        ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(wrappers.size());
-        
-        for (MethodWrapper method : wrappers) {
-            retVal.add(new MethodAltMethodImpl(method.getMethod(), helper));
+    public List<AltMethod> getMethods() {
+        try {
+            lock.lock();
+            if (methods != null) return methods;
+            
+            Set<MethodWrapper> wrappers = helper.getAllMethods(clazz);
+            ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(wrappers.size());
+            
+            for (MethodWrapper method : wrappers) {
+                retVal.add(new MethodAltMethodImpl(method.getMethod(), helper));
+            }
+            
+            methods = Collections.unmodifiableList(retVal);
+            return methods;
+        } finally {
+            lock.unlock();
         }
-        
-        methods = Collections.unmodifiableList(retVal);
-        return methods;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/ClassAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/ClassAltClassImpl.java
@@ -89,8 +89,8 @@ public class ClassAltClassImpl implements AltClass {
      */
     @Override
     public List<AltAnnotation> getAnnotations() {
+        lock.lock();
         try {
-            lock.lock();
             if (annotations != null) return annotations;
             
             Annotation annotationz[] = clazz.getAnnotations();
@@ -112,8 +112,8 @@ public class ClassAltClassImpl implements AltClass {
      */
     @Override
     public List<AltMethod> getMethods() {
+        lock.lock();
         try {
-            lock.lock();
             if (methods != null) return methods;
             
             Set<MethodWrapper> wrappers = helper.getAllMethods(clazz);

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/MethodAltMethodImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/MethodAltMethodImpl.java
@@ -76,8 +76,8 @@ public class MethodAltMethodImpl implements AltMethod {
      */
     @Override
     public List<AltClass> getParameterTypes() {
+        lock.lock();
         try {
-            lock.lock();
             if (parameterTypes != null) return parameterTypes;
             
             Class<?> pTypes[] = method.getParameterTypes();
@@ -151,8 +151,8 @@ public class MethodAltMethodImpl implements AltMethod {
      */
     @Override
     public List<AltAnnotation> getAnnotations() {
+        lock.lock();
         try {
-            lock.lock();
             if (altAnnotations != null) return altAnnotations;
             
             Annotation annotations[] = method.getAnnotations();

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/MethodAltMethodImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/clazz/MethodAltMethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.utilities.reflection.ClassReflectionHelper;
 import org.glassfish.hk2.utilities.reflection.ReflectionHelper;
@@ -35,6 +36,7 @@ import org.glassfish.hk2.xml.internal.alt.MethodInformationI;
  *
  */
 public class MethodAltMethodImpl implements AltMethod {
+    private final ReentrantLock lock = new ReentrantLock();
     private final Method method;
     private final ClassReflectionHelper helper;
     private List<AltClass> parameterTypes;
@@ -73,18 +75,23 @@ public class MethodAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getParameterTypes()
      */
     @Override
-    public synchronized List<AltClass> getParameterTypes() {
-        if (parameterTypes != null) return parameterTypes;
-        
-        Class<?> pTypes[] = method.getParameterTypes();
-        List<AltClass> retVal = new ArrayList<AltClass>(pTypes.length);
-        
-        for (Class<?> pType : pTypes) {
-            retVal.add(new ClassAltClassImpl(pType, helper));
+    public List<AltClass> getParameterTypes() {
+        try {
+            lock.lock();
+            if (parameterTypes != null) return parameterTypes;
+            
+            Class<?> pTypes[] = method.getParameterTypes();
+            List<AltClass> retVal = new ArrayList<AltClass>(pTypes.length);
+            
+            for (Class<?> pType : pTypes) {
+                retVal.add(new ClassAltClassImpl(pType, helper));
+            }
+            
+            parameterTypes = Collections.unmodifiableList(retVal);
+            return parameterTypes;
+        } finally {
+            lock.unlock();
         }
-        
-        parameterTypes = Collections.unmodifiableList(retVal);
-        return parameterTypes;
     }
 
     /* (non-Javadoc)
@@ -143,18 +150,23 @@ public class MethodAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (altAnnotations != null) return altAnnotations;
-        
-        Annotation annotations[] = method.getAnnotations();
-        ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotations.length);
-        
-        for (Annotation annotation : annotations) {
-            retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+    public List<AltAnnotation> getAnnotations() {
+        try {
+            lock.lock();
+            if (altAnnotations != null) return altAnnotations;
+            
+            Annotation annotations[] = method.getAnnotations();
+            ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annotations.length);
+            
+            for (Annotation annotation : annotations) {
+                retVal.add(new AnnotationAltAnnotationImpl(annotation, helper));
+            }
+            
+            altAnnotations = Collections.unmodifiableList(retVal);
+            return altAnnotations;
+        } finally {
+            lock.unlock();
         }
-        
-        altAnnotations = Collections.unmodifiableList(retVal);
-        return altAnnotations;
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/AnnotationMirrorAltAnnotationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/AnnotationMirrorAltAnnotationImpl.java
@@ -59,8 +59,8 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
      */
     @Override
     public String annotationType() {
+        lock.lock();
         try {
-            lock.lock();
             if (type != null) return type;
             
             DeclaredType dt = annotation.getAnnotationType();
@@ -95,8 +95,8 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
     
     @Override
     public String[] getStringArrayValue(String methodName) {
+        lock.lock();
         try {
-            lock.lock();
             getAnnotationValues();
             
             Object retVal = values.get(methodName);
@@ -129,8 +129,8 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
      */
     @Override
     public Map<String, Object> getAnnotationValues() {
+        lock.lock();
         try {
-            lock.lock();
             if (values != null) return values;
             
             Map<? extends ExecutableElement, ? extends AnnotationValue> rawValues =

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/AnnotationMirrorAltAnnotationImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/AnnotationMirrorAltAnnotationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -42,6 +43,7 @@ import org.glassfish.hk2.xml.internal.alt.AltEnum;
  *
  */
 public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
+    private final ReentrantLock lock = new ReentrantLock();
     private final AnnotationMirror annotation;
     private final ProcessingEnvironment processingEnv;
     private String type;
@@ -56,14 +58,19 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#annotationType()
      */
     @Override
-    public synchronized String annotationType() {
-        if (type != null) return type;
-        
-        DeclaredType dt = annotation.getAnnotationType();
-        TypeElement clazzType = (TypeElement) dt.asElement();
-        type = Utilities.convertNameToString(clazzType.getQualifiedName());
-        
-        return type;
+    public String annotationType() {
+        try {
+            lock.lock();
+            if (type != null) return type;
+            
+            DeclaredType dt = annotation.getAnnotationType();
+            TypeElement clazzType = (TypeElement) dt.asElement();
+            type = Utilities.convertNameToString(clazzType.getQualifiedName());
+            
+            return type;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
@@ -87,15 +94,20 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
     }
     
     @Override
-    public synchronized String[] getStringArrayValue(String methodName) {
-        getAnnotationValues();
-        
-        Object retVal = values.get(methodName);
-        if (retVal == null || !(retVal instanceof String[])) {
-            return null;
+    public String[] getStringArrayValue(String methodName) {
+        try {
+            lock.lock();
+            getAnnotationValues();
+            
+            Object retVal = values.get(methodName);
+            if (retVal == null || !(retVal instanceof String[])) {
+                return null;
+            }
+            
+            return (String[]) values.get(methodName);
+        } finally {
+            lock.unlock();
         }
-        
-        return (String[]) values.get(methodName);
     }
     
     @Override
@@ -116,206 +128,211 @@ public class AnnotationMirrorAltAnnotationImpl implements AltAnnotation {
      * @see org.glassfish.hk2.xml.internal.alt.AltAnnotation#getAnnotationValues()
      */
     @Override
-    public synchronized Map<String, Object> getAnnotationValues() {
-        if (values != null) return values;
-        
-        Map<? extends ExecutableElement, ? extends AnnotationValue> rawValues =
-                processingEnv.getElementUtils().getElementValuesWithDefaults(annotation);
-        Map<String, Object> retVal = new TreeMap<String, Object>();
-        
-        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : rawValues.entrySet()) {
-            ExecutableElement annoMethod = entry.getKey();
-            AnnotationValue annoValue = entry.getValue();
+    public Map<String, Object> getAnnotationValues() {
+        try {
+            lock.lock();
+            if (values != null) return values;
             
-            String key = Utilities.convertNameToString(annoMethod.getSimpleName());
-            Object value = annoValue.getValue();
+            Map<? extends ExecutableElement, ? extends AnnotationValue> rawValues =
+                    processingEnv.getElementUtils().getElementValuesWithDefaults(annotation);
+            Map<String, Object> retVal = new TreeMap<String, Object>();
             
-            if (value instanceof TypeMirror) {
-                // The annotation method is a java.lang.Class
-                value = Utilities.convertTypeMirror((TypeMirror) value, processingEnv);
-            }
-            else if (value instanceof VariableElement) {
-                // The annotation method is an Enum
-                VariableElement variable = (VariableElement) value;
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : rawValues.entrySet()) {
+                ExecutableElement annoMethod = entry.getKey();
+                AnnotationValue annoValue = entry.getValue();
                 
-                TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
+                String key = Utilities.convertNameToString(annoMethod.getSimpleName());
+                Object value = annoValue.getValue();
                 
-                String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
-                String annoVal = Utilities.convertNameToString(variable.getSimpleName());
-                
-                value = new StringAltEnumImpl(annoClassName, annoVal);
-            }
-            else if (value instanceof AnnotationMirror) {
-                throw new AssertionError("The annotation " + annotation + " key " + key + " has unimplemented type AnnotationMirror");
-            }
-            else if (value instanceof List) {
-                // The annotation method returns an array of something
-                ArrayType returnType = (ArrayType) annoMethod.getReturnType();
-                TypeMirror arrayTypeMirror = returnType.getComponentType();
-                TypeKind arrayTypeKind = arrayTypeMirror.getKind();
-                
-                @SuppressWarnings("unchecked")
-                List<? extends AnnotationValue> array = ((List<? extends AnnotationValue>) value);
-                
-                if (TypeKind.INT.equals(arrayTypeMirror.getKind())) {
-                    int[] iValue = new int[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Integer) item.getValue();
-                    }
-                    
-                    value = iValue;
+                if (value instanceof TypeMirror) {
+                    // The annotation method is a java.lang.Class
+                    value = Utilities.convertTypeMirror((TypeMirror) value, processingEnv);
                 }
-                else if (TypeKind.DECLARED.equals(arrayTypeMirror.getKind())) {
-                    AltClass[] cValue = new AltClass[array.size()];
-                    AltEnum[] eValue = new AltEnum[array.size()];
-                    String[] sValue = new String[array.size()];
-                    AltAnnotation[] aValue = new AltAnnotation[array.size()];
+                else if (value instanceof VariableElement) {
+                    // The annotation method is an Enum
+                    VariableElement variable = (VariableElement) value;
                     
-                    boolean isClass = true;
-                    boolean isEnum = true;
-                    boolean isAnnos = false;
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        Object itemValue = item.getValue();
-                        if (itemValue instanceof TypeMirror) {
-                            isClass = true;
-                            isEnum = false;
-                            isAnnos = false;
-                            
-                            cValue[lcv++] = Utilities.convertTypeMirror((TypeMirror) itemValue, processingEnv);
+                    TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
+                    
+                    String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
+                    String annoVal = Utilities.convertNameToString(variable.getSimpleName());
+                    
+                    value = new StringAltEnumImpl(annoClassName, annoVal);
+                }
+                else if (value instanceof AnnotationMirror) {
+                    throw new AssertionError("The annotation " + annotation + " key " + key + " has unimplemented type AnnotationMirror");
+                }
+                else if (value instanceof List) {
+                    // The annotation method returns an array of something
+                    ArrayType returnType = (ArrayType) annoMethod.getReturnType();
+                    TypeMirror arrayTypeMirror = returnType.getComponentType();
+                    TypeKind arrayTypeKind = arrayTypeMirror.getKind();
+                    
+                    @SuppressWarnings("unchecked")
+                    List<? extends AnnotationValue> array = ((List<? extends AnnotationValue>) value);
+                    
+                    if (TypeKind.INT.equals(arrayTypeMirror.getKind())) {
+                        int[] iValue = new int[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Integer) item.getValue();
                         }
-                        else if (itemValue instanceof VariableElement) {
-                            isClass = false;
-                            isEnum = true;
-                            isAnnos = false;
-                            
-                            VariableElement variable = (VariableElement) itemValue;
-                            
-                            TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
-                            
-                            String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
-                            String annoVal = Utilities.convertNameToString(variable.getSimpleName());
-                            
-                            eValue[lcv++] = new StringAltEnumImpl(annoClassName, annoVal);
+                        
+                        value = iValue;
+                    }
+                    else if (TypeKind.DECLARED.equals(arrayTypeMirror.getKind())) {
+                        AltClass[] cValue = new AltClass[array.size()];
+                        AltEnum[] eValue = new AltEnum[array.size()];
+                        String[] sValue = new String[array.size()];
+                        AltAnnotation[] aValue = new AltAnnotation[array.size()];
+                        
+                        boolean isClass = true;
+                        boolean isEnum = true;
+                        boolean isAnnos = false;
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            Object itemValue = item.getValue();
+                            if (itemValue instanceof TypeMirror) {
+                                isClass = true;
+                                isEnum = false;
+                                isAnnos = false;
+                                
+                                cValue[lcv++] = Utilities.convertTypeMirror((TypeMirror) itemValue, processingEnv);
+                            }
+                            else if (itemValue instanceof VariableElement) {
+                                isClass = false;
+                                isEnum = true;
+                                isAnnos = false;
+                                
+                                VariableElement variable = (VariableElement) itemValue;
+                                
+                                TypeElement enclosing = (TypeElement) variable.getEnclosingElement();
+                                
+                                String annoClassName = Utilities.convertNameToString(enclosing.getQualifiedName());
+                                String annoVal = Utilities.convertNameToString(variable.getSimpleName());
+                                
+                                eValue[lcv++] = new StringAltEnumImpl(annoClassName, annoVal);
+                            }
+                            else if (itemValue instanceof String) {
+                                isClass = false;
+                                isEnum = false;
+                                isAnnos = false;
+                                
+                                sValue[lcv++] = (String) itemValue;
+                            }
+                            else if (itemValue instanceof List) {
+                                throw new AssertionError("Unimplemented declared List type in " + this);
+                            }
+                            else if (itemValue instanceof AnnotationMirror) {
+                                isClass = false;
+                                isEnum = false;
+                                isAnnos = true;
+                                
+                                aValue[lcv++] = new AnnotationMirrorAltAnnotationImpl((AnnotationMirror) itemValue, processingEnv);
+                            }
+                            else {
+                                throw new AssertionError("Unknown declared type: " + itemValue.getClass().getName());
+                            }
                         }
-                        else if (itemValue instanceof String) {
-                            isClass = false;
-                            isEnum = false;
-                            isAnnos = false;
-                            
-                            sValue[lcv++] = (String) itemValue;
+                        
+                        if (isClass) {
+                            value = cValue;
                         }
-                        else if (itemValue instanceof List) {
-                            throw new AssertionError("Unimplemented declared List type in " + this);
+                        else if (isEnum) {
+                            value = eValue;
                         }
-                        else if (itemValue instanceof AnnotationMirror) {
-                            isClass = false;
-                            isEnum = false;
-                            isAnnos = true;
-                            
-                            aValue[lcv++] = new AnnotationMirrorAltAnnotationImpl((AnnotationMirror) itemValue, processingEnv);
+                        else if (isAnnos) {
+                            value = aValue;
                         }
                         else {
-                            throw new AssertionError("Unknown declared type: " + itemValue.getClass().getName());
+                            value = sValue;
                         }
                     }
-                    
-                    if (isClass) {
-                        value = cValue;
+                    else if (TypeKind.LONG.equals(arrayTypeMirror.getKind())) {
+                        long[] iValue = new long[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Long) item.getValue();
+                        }
+                        
+                        value = iValue;
                     }
-                    else if (isEnum) {
-                        value = eValue;
+                    else if (TypeKind.SHORT.equals(arrayTypeMirror.getKind())) {
+                        short[] iValue = new short[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Short) item.getValue();
+                        }
+                        
+                        value = iValue;
                     }
-                    else if (isAnnos) {
-                        value = aValue;
+                    else if (TypeKind.CHAR.equals(arrayTypeMirror.getKind())) {
+                        char[] iValue = new char[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Character) item.getValue();
+                        }
+                        
+                        value = iValue;
+                    }
+                    else if (TypeKind.FLOAT.equals(arrayTypeMirror.getKind())) {
+                        float[] iValue = new float[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Float) item.getValue();
+                        }
+                        
+                        value = iValue;
+                    }
+                    else if (TypeKind.DOUBLE.equals(arrayTypeMirror.getKind())) {
+                        double[] iValue = new double[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Double) item.getValue();
+                        }
+                        
+                        value = iValue;
+                    }
+                    else if (TypeKind.BOOLEAN.equals(arrayTypeMirror.getKind())) {
+                        boolean[] iValue = new boolean[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Boolean) item.getValue();
+                        }
+                        
+                        value = iValue;
+                    }
+                    else if (TypeKind.BYTE.equals(arrayTypeMirror.getKind())) {
+                        byte[] iValue = new byte[array.size()];
+                        
+                        int lcv = 0;
+                        for (AnnotationValue item : array) {
+                            iValue[lcv++] = (Byte) item.getValue();
+                        }
+                        
+                        value = iValue;
+                        
                     }
                     else {
-                        value = sValue;
+                        throw new AssertionError("Array type " + arrayTypeKind + " is not implemented");
                     }
                 }
-                else if (TypeKind.LONG.equals(arrayTypeMirror.getKind())) {
-                    long[] iValue = new long[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Long) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.SHORT.equals(arrayTypeMirror.getKind())) {
-                    short[] iValue = new short[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Short) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.CHAR.equals(arrayTypeMirror.getKind())) {
-                    char[] iValue = new char[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Character) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.FLOAT.equals(arrayTypeMirror.getKind())) {
-                    float[] iValue = new float[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Float) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.DOUBLE.equals(arrayTypeMirror.getKind())) {
-                    double[] iValue = new double[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Double) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.BOOLEAN.equals(arrayTypeMirror.getKind())) {
-                    boolean[] iValue = new boolean[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Boolean) item.getValue();
-                    }
-                    
-                    value = iValue;
-                }
-                else if (TypeKind.BYTE.equals(arrayTypeMirror.getKind())) {
-                    byte[] iValue = new byte[array.size()];
-                    
-                    int lcv = 0;
-                    for (AnnotationValue item : array) {
-                        iValue[lcv++] = (Byte) item.getValue();
-                    }
-                    
-                    value = iValue;
-                    
-                }
-                else {
-                    throw new AssertionError("Array type " + arrayTypeKind + " is not implemented");
-                }
+                
+                retVal.put(key, value);
             }
             
-            retVal.put(key, value);
+            values = Collections.unmodifiableMap(retVal);
+            return values;
+        } finally {
+            lock.unlock();
         }
-        
-        values = Collections.unmodifiableMap(retVal);
-        return values;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ArrayTypeAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ArrayTypeAltClassImpl.java
@@ -126,8 +126,8 @@ public class ArrayTypeAltClassImpl implements AltClass {
      */
     @Override
     public String getName() {
+        lock.lock();
         try {
-            lock.lock();
             if (name != null) return name;
             
             calculateNames();
@@ -143,8 +143,8 @@ public class ArrayTypeAltClassImpl implements AltClass {
      */
     @Override
     public String getSimpleName() {
+        lock.lock();
         try {
-            lock.lock();
             if (simpleName != null) return simpleName;
             
             calculateNames();

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ArrayTypeAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ArrayTypeAltClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.xml.internal.alt.papi;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.ArrayType;
@@ -34,6 +35,7 @@ import org.glassfish.hk2.xml.internal.alt.AltMethod;
  *
  */
 public class ArrayTypeAltClassImpl implements AltClass {
+    private final ReentrantLock lock = new ReentrantLock();
     private final ArrayType arrayType;
     private final ProcessingEnvironment processingEnv;
     private String name;
@@ -123,24 +125,34 @@ public class ArrayTypeAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getName()
      */
     @Override
-    public synchronized String getName() {
-        if (name != null) return name;
-        
-        calculateNames();
-        
-        return name;
+    public String getName() {
+        try {
+            lock.lock();
+            if (name != null) return name;
+            
+            calculateNames();
+            
+            return name;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getSimpleName()
      */
     @Override
-    public synchronized String getSimpleName() {
-        if (simpleName != null) return simpleName;
-        
-        calculateNames();
-        
-        return simpleName;
+    public String getSimpleName() {
+        try {
+            lock.lock();
+            if (simpleName != null) return simpleName;
+            
+            calculateNames();
+            
+            return simpleName;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ElementAltMethodImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ElementAltMethodImpl.java
@@ -72,8 +72,8 @@ public class ElementAltMethodImpl implements AltMethod {
      */
     @Override
     public AltClass getReturnType() {
+        lock.lock();
         try {
-            lock.lock();
             if (returnType != null) return returnType;
             
             ExecutableType executable = (ExecutableType) method.asType();
@@ -93,8 +93,8 @@ public class ElementAltMethodImpl implements AltMethod {
      */
     @Override
     public List<AltClass> getParameterTypes() {
+        lock.lock();
         try {
-            lock.lock();
             if (parameters != null) return parameters;
             
             ExecutableType executable = (ExecutableType) method.asType();
@@ -167,8 +167,8 @@ public class ElementAltMethodImpl implements AltMethod {
      */
     @Override
     public AltAnnotation getAnnotation(String annotation) {
+        lock.lock();
         try {
-            lock.lock();
             if (annotations == null) {
                 getAnnotations();
             }
@@ -184,8 +184,8 @@ public class ElementAltMethodImpl implements AltMethod {
      */
     @Override
     public List<AltAnnotation> getAnnotations() {
+        lock.lock();
         try {
-            lock.lock();
             if (annotations != null) {
                 return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
             }

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ElementAltMethodImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/ElementAltMethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -45,6 +46,7 @@ import org.glassfish.hk2.xml.internal.alt.clazz.ClassAltClassImpl;
  *
  */
 public class ElementAltMethodImpl implements AltMethod {
+    private final ReentrantLock lock = new ReentrantLock();
     private final ExecutableElement method;
     private final ProcessingEnvironment processingEnv;
     private List<AltClass> parameters;
@@ -69,36 +71,46 @@ public class ElementAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getReturnType()
      */
     @Override
-    public synchronized AltClass getReturnType() {
-        if (returnType != null) return returnType;
-        
-        ExecutableType executable = (ExecutableType) method.asType();
-        TypeMirror returnMirror = executable.getReturnType();
-        
-        AltClass retVal = Utilities.convertTypeMirror(returnMirror, processingEnv);
-        
-        returnType = retVal;
-        return returnType;
+    public AltClass getReturnType() {
+        try {
+            lock.lock();
+            if (returnType != null) return returnType;
+            
+            ExecutableType executable = (ExecutableType) method.asType();
+            TypeMirror returnMirror = executable.getReturnType();
+            
+            AltClass retVal = Utilities.convertTypeMirror(returnMirror, processingEnv);
+            
+            returnType = retVal;
+            return returnType;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getParameterTypes()
      */
     @Override
-    public synchronized List<AltClass> getParameterTypes() {
-        if (parameters != null) return parameters;
-        
-        ExecutableType executable = (ExecutableType) method.asType();
-        List<? extends TypeMirror> paramMirrors = executable.getParameterTypes();
-        
-        List<AltClass> retVal = new ArrayList<AltClass>(paramMirrors.size());
-        
-        for (TypeMirror paramMirror : paramMirrors) {
-            retVal.add(Utilities.convertTypeMirror(paramMirror, processingEnv));
+    public List<AltClass> getParameterTypes() {
+        try {
+            lock.lock();
+            if (parameters != null) return parameters;
+            
+            ExecutableType executable = (ExecutableType) method.asType();
+            List<? extends TypeMirror> paramMirrors = executable.getParameterTypes();
+            
+            List<AltClass> retVal = new ArrayList<AltClass>(paramMirrors.size());
+            
+            for (TypeMirror paramMirror : paramMirrors) {
+                retVal.add(Utilities.convertTypeMirror(paramMirror, processingEnv));
+            }
+            
+            parameters = Collections.unmodifiableList(retVal);
+            return parameters;
+        } finally {
+            lock.unlock();
         }
-        
-        parameters = Collections.unmodifiableList(retVal);
-        return parameters;
     }
 
     /* (non-Javadoc)
@@ -154,33 +166,43 @@ public class ElementAltMethodImpl implements AltMethod {
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getAnnotation(java.lang.String)
      */
     @Override
-    public synchronized AltAnnotation getAnnotation(String annotation) {
-        if (annotations == null) {
-            getAnnotations();
+    public AltAnnotation getAnnotation(String annotation) {
+        try {
+            lock.lock();
+            if (annotations == null) {
+                getAnnotations();
+            }
+            
+            return annotations.get(annotation);
+        } finally {
+            lock.unlock();
         }
-        
-        return annotations.get(annotation);
     }
 
     /* (non-Javadoc)
      * @see org.glassfish.hk2.xml.internal.alt.AltMethod#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (annotations != null) {
-            return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
-        }
-        
-        Map<String, AltAnnotation> retVal = new LinkedHashMap<String, AltAnnotation>();
-        
-        for (AnnotationMirror annoMirror : method.getAnnotationMirrors()) {
-            AnnotationMirrorAltAnnotationImpl addMe = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
+    public List<AltAnnotation> getAnnotations() {
+        try {
+            lock.lock();
+            if (annotations != null) {
+                return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
+            }
             
-            retVal.put(addMe.annotationType(), addMe);
+            Map<String, AltAnnotation> retVal = new LinkedHashMap<String, AltAnnotation>();
+            
+            for (AnnotationMirror annoMirror : method.getAnnotationMirrors()) {
+                AnnotationMirrorAltAnnotationImpl addMe = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
+                
+                retVal.put(addMe.annotationType(), addMe);
+            }
+            
+            annotations = Collections.unmodifiableMap(retVal);
+            return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
+        } finally {
+            lock.unlock();
         }
-        
-        annotations = Collections.unmodifiableMap(retVal);
-        return Collections.unmodifiableList(new ArrayList<AltAnnotation>(annotations.values()));
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/TypeElementAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/TypeElementAltClassImpl.java
@@ -82,8 +82,8 @@ public class TypeElementAltClassImpl implements AltClass {
      */
     @Override
     public List<AltAnnotation> getAnnotations() {
+        lock.lock();
         try {
-            lock.lock();
             if (annotations != null) return annotations;
             
             List<? extends AnnotationMirror> annoMirrors = processingEnv.getElementUtils().getAllAnnotationMirrors(clazz);
@@ -172,8 +172,8 @@ public class TypeElementAltClassImpl implements AltClass {
      */
     @Override
     public List<AltMethod> getMethods() {
+        lock.lock();
         try {
-            lock.lock();
             if (methods != null) return methods;
             
             List<? extends Element> innerElements = processingEnv.getElementUtils().getAllMembers(clazz);

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/TypeElementAltClassImpl.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/internal/alt/papi/TypeElementAltClassImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -48,6 +49,7 @@ import org.glassfish.hk2.xml.internal.alt.clazz.ClassAltClassImpl;
  *
  */
 public class TypeElementAltClassImpl implements AltClass {
+    private final ReentrantLock lock = new ReentrantLock();
     private final TypeElement clazz;
     private final ProcessingEnvironment processingEnv;
     
@@ -79,21 +81,26 @@ public class TypeElementAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getAnnotations()
      */
     @Override
-    public synchronized List<AltAnnotation> getAnnotations() {
-        if (annotations != null) return annotations;
-        
-        List<? extends AnnotationMirror> annoMirrors = processingEnv.getElementUtils().getAllAnnotationMirrors(clazz);
-        
-        ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annoMirrors.size());
-        
-        for (AnnotationMirror annoMirror : annoMirrors) {
-            AnnotationMirrorAltAnnotationImpl anno = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
+    public List<AltAnnotation> getAnnotations() {
+        try {
+            lock.lock();
+            if (annotations != null) return annotations;
             
-            retVal.add(anno);
+            List<? extends AnnotationMirror> annoMirrors = processingEnv.getElementUtils().getAllAnnotationMirrors(clazz);
+            
+            ArrayList<AltAnnotation> retVal = new ArrayList<AltAnnotation>(annoMirrors.size());
+            
+            for (AnnotationMirror annoMirror : annoMirrors) {
+                AnnotationMirrorAltAnnotationImpl anno = new AnnotationMirrorAltAnnotationImpl(annoMirror, processingEnv);
+                
+                retVal.add(anno);
+            }
+            
+            annotations = Collections.unmodifiableList(new ArrayList<AltAnnotation>(retVal));
+            return annotations;
+        } finally {
+            lock.unlock();
         }
-        
-        annotations = Collections.unmodifiableList(new ArrayList<AltAnnotation>(retVal));
-        return annotations;
     }
     
     private static final Set<String> POSSIBLE_NO_HANDLE = new HashSet<String>(Arrays.asList(new String[] {
@@ -164,51 +171,56 @@ public class TypeElementAltClassImpl implements AltClass {
      * @see org.glassfish.hk2.xml.internal.alt.AltClass#getMethods()
      */
     @Override
-    public synchronized List<AltMethod> getMethods() {
-        if (methods != null) return methods;
-        
-        List<? extends Element> innerElements = processingEnv.getElementUtils().getAllMembers(clazz);
-        
-        TreeMap<String, List<Element>> reorderByEnclosingClass = new TreeMap<String, List<Element>>();
-        
-        String clazzName = getName();
-        for (Element innerElementElement : innerElements) {
-            if (isMethodToGenerate(innerElementElement)) {
-                TypeElement enclosingElement = (TypeElement) innerElementElement.getEnclosingElement();
-                
-                String enclosingName = Utilities.convertNameToString(processingEnv.getElementUtils().getBinaryName(enclosingElement));
-                
-                List<Element> addedList = reorderByEnclosingClass.get(enclosingName);
-                if (addedList == null) {
-                    addedList = new LinkedList<Element>();
-                    
-                    reorderByEnclosingClass.put(enclosingName, addedList);
-                }
-                
-                addedList.add(innerElementElement);
-            }
-        }
-        
-        List<Element> innerElementsReordered = new ArrayList<Element>(innerElements.size());
-        for (Map.Entry<String, List<Element>> listByEnclosing : reorderByEnclosingClass.entrySet()) {
-            String enclosingClass = listByEnclosing.getKey();
-            if (clazzName.equals(enclosingClass)) continue;
+    public List<AltMethod> getMethods() {
+        try {
+            lock.lock();
+            if (methods != null) return methods;
             
-            innerElementsReordered.addAll(listByEnclosing.getValue());
+            List<? extends Element> innerElements = processingEnv.getElementUtils().getAllMembers(clazz);
+            
+            TreeMap<String, List<Element>> reorderByEnclosingClass = new TreeMap<String, List<Element>>();
+            
+            String clazzName = getName();
+            for (Element innerElementElement : innerElements) {
+                if (isMethodToGenerate(innerElementElement)) {
+                    TypeElement enclosingElement = (TypeElement) innerElementElement.getEnclosingElement();
+                    
+                    String enclosingName = Utilities.convertNameToString(processingEnv.getElementUtils().getBinaryName(enclosingElement));
+                    
+                    List<Element> addedList = reorderByEnclosingClass.get(enclosingName);
+                    if (addedList == null) {
+                        addedList = new LinkedList<Element>();
+                        
+                        reorderByEnclosingClass.put(enclosingName, addedList);
+                    }
+                    
+                    addedList.add(innerElementElement);
+                }
+            }
+            
+            List<Element> innerElementsReordered = new ArrayList<Element>(innerElements.size());
+            for (Map.Entry<String, List<Element>> listByEnclosing : reorderByEnclosingClass.entrySet()) {
+                String enclosingClass = listByEnclosing.getKey();
+                if (clazzName.equals(enclosingClass)) continue;
+                
+                innerElementsReordered.addAll(listByEnclosing.getValue());
+            }
+            
+            List<Element> topClass = reorderByEnclosingClass.get(clazzName);
+            if (topClass != null) {
+                innerElementsReordered.addAll(topClass);
+            }
+            
+            ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(innerElementsReordered.size());
+            for (Element innerElementElement : innerElementsReordered) {
+                retVal.add(new ElementAltMethodImpl(innerElementElement, processingEnv));
+            }
+            
+            methods = Collections.unmodifiableList(retVal);
+            return methods;
+        } finally {
+            lock.unlock();
         }
-        
-        List<Element> topClass = reorderByEnclosingClass.get(clazzName);
-        if (topClass != null) {
-            innerElementsReordered.addAll(topClass);
-        }
-        
-        ArrayList<AltMethod> retVal = new ArrayList<AltMethod>(innerElementsReordered.size());
-        for (Element innerElementElement : innerElementsReordered) {
-            retVal.add(new ElementAltMethodImpl(innerElementElement, processingEnv));
-        }
-        
-        methods = Collections.unmodifiableList(retVal);
-        return methods;
     }
     
     @Override

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/jaxb/internal/BaseHK2JAXBBean.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/jaxb/internal/BaseHK2JAXBBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.namespace.QName;
@@ -79,7 +80,9 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     
     private final static String EMPTY = "";
     public final static char XML_PATH_SEPARATOR = '/';
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
+
     /**
      * All fields, including child lists and direct children for beans
      * with no namespace specified (##default)
@@ -221,8 +224,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
         
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                try {
+                    lock.lock();
                     nBeanLikeMap.setValue(propNamespace, propName, propValue);
+                } finally {
+                    lock.unlock();
                 }
             }
             else {
@@ -434,9 +440,12 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
         
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                try {
+                    lock.lock();
                     isSet = nBeanLikeMap.isSet(propNamespace, propName);
                     retVal = nBeanLikeMap.getValue(propNamespace, propName);
+                } finally {
+                    lock.unlock();
                 }
             }
             else {
@@ -933,8 +942,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public boolean _hasProperty(String propNamespace, String propName) {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                try {
+                    lock.lock();
                     return nBeanLikeMap.isSet(propNamespace, propName);
+                } finally {
+                    lock.unlock();
                 }
             }
             
@@ -957,8 +969,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public Map<String, Object> _getBeanLikeMap() {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                try {
+                    lock.lock();
                     return Collections.unmodifiableMap(nBeanLikeMap.getBeanLikeMap(namespaceToPrefixMap));
+                } finally {
+                    lock.unlock();
                 }
             }
             return Collections.unmodifiableMap(nBeanLikeMap.getBeanLikeMap(namespaceToPrefixMap));
@@ -976,8 +991,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public Map<QName, Object> _getQNameMap() {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                try {
+                    lock.lock();
                     return Collections.unmodifiableMap(nBeanLikeMap.getQNameMap());
+                } finally {
+                    lock.unlock();
                 }
             }
             return Collections.unmodifiableMap(nBeanLikeMap.getQNameMap());
@@ -1300,8 +1318,11 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public boolean _isSet(String propNamespace, String propName) {
         if (changeControl == null) {
             if (active) {
-                synchronized (this) {
+                try {
+                    lock.lock();
                     return nBeanLikeMap.isSet(propNamespace, propName);
+                } finally {
+                    lock.unlock();
                 }
             }
             

--- a/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/jaxb/internal/BaseHK2JAXBBean.java
+++ b/hk2-configuration/persistence/hk2-xml/main/src/main/java/org/glassfish/hk2/xml/jaxb/internal/BaseHK2JAXBBean.java
@@ -224,8 +224,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
         
         if (changeControl == null) {
             if (active) {
+                lock.lock();
                 try {
-                    lock.lock();
                     nBeanLikeMap.setValue(propNamespace, propName, propValue);
                 } finally {
                     lock.unlock();
@@ -440,8 +440,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
         
         if (changeControl == null) {
             if (active) {
+                lock.lock();
                 try {
-                    lock.lock();
                     isSet = nBeanLikeMap.isSet(propNamespace, propName);
                     retVal = nBeanLikeMap.getValue(propNamespace, propName);
                 } finally {
@@ -942,8 +942,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public boolean _hasProperty(String propNamespace, String propName) {
         if (changeControl == null) {
             if (active) {
+                lock.lock();
                 try {
-                    lock.lock();
                     return nBeanLikeMap.isSet(propNamespace, propName);
                 } finally {
                     lock.unlock();
@@ -969,8 +969,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public Map<String, Object> _getBeanLikeMap() {
         if (changeControl == null) {
             if (active) {
+                lock.lock();
                 try {
-                    lock.lock();
                     return Collections.unmodifiableMap(nBeanLikeMap.getBeanLikeMap(namespaceToPrefixMap));
                 } finally {
                     lock.unlock();
@@ -991,8 +991,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public Map<QName, Object> _getQNameMap() {
         if (changeControl == null) {
             if (active) {
+                lock.lock();
                 try {
-                    lock.lock();
                     return Collections.unmodifiableMap(nBeanLikeMap.getQNameMap());
                 } finally {
                     lock.unlock();
@@ -1318,8 +1318,8 @@ public abstract class BaseHK2JAXBBean implements XmlHk2ConfigurationBean, Serial
     public boolean _isSet(String propNamespace, String propName) {
         if (changeControl == null) {
             if (active) {
+                lock.lock();
                 try {
-                    lock.lock();
                     return nBeanLikeMap.isSet(propNamespace, propName);
                 } finally {
                     lock.unlock();

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileBean.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileBean.java
@@ -60,8 +60,8 @@ public class PropertyFileBean {
      * @return A copy of the type name to bean class mapping
      */
     public Map<String, Class<?>> getTypeMapping() {
+        lock.lock();
         try {
-            lock.lock();
             return new HashMap<String, Class<?>>(mapping);
         } finally {
             lock.unlock();
@@ -76,8 +76,8 @@ public class PropertyFileBean {
      * May not be null
      */
     public void addTypeMapping(String typeName, Class<?> beanClass) {
+        lock.lock();
         try {
-            lock.lock();
             mapping.put(typeName, beanClass);
         } finally {
             lock.unlock();
@@ -93,8 +93,8 @@ public class PropertyFileBean {
      * was no type mapping with the given name
      */
     public Class<?> removeTypeMapping(String typeName) {
+        lock.lock();
         try {
-            lock.lock();
             return mapping.remove(typeName);
         } finally {
             lock.unlock();
@@ -110,8 +110,8 @@ public class PropertyFileBean {
      * was no type mapping with the given name
      */
     public Class<?> getTypeMapping(String typeName) {
+        lock.lock();
         try {
-            lock.lock();
             return mapping.get(typeName);
         } finally {
             lock.unlock();

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileBean.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/PropertyFileBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.hk2.configuration.persistence.properties;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This bean configures the PropertyFileService itself.  An implementation
@@ -35,6 +36,7 @@ public class PropertyFileBean {
     /** The name of the single instance of this bean */
     public final static String INSTANCE_NAME = "DEFAULT";
     
+    private final ReentrantLock lock = new ReentrantLock();
     private final HashMap<String, Class<?>> mapping = new HashMap<String, Class<?>>();
     
     /**
@@ -58,8 +60,11 @@ public class PropertyFileBean {
      * @return A copy of the type name to bean class mapping
      */
     public Map<String, Class<?>> getTypeMapping() {
-        synchronized (mapping) {
+        try {
+            lock.lock();
             return new HashMap<String, Class<?>>(mapping);
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -71,8 +76,11 @@ public class PropertyFileBean {
      * May not be null
      */
     public void addTypeMapping(String typeName, Class<?> beanClass) {
-        synchronized (mapping) {
+        try {
+            lock.lock();
             mapping.put(typeName, beanClass);
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -85,8 +93,11 @@ public class PropertyFileBean {
      * was no type mapping with the given name
      */
     public Class<?> removeTypeMapping(String typeName) {
-        synchronized (mapping) {
+        try {
+            lock.lock();
             return mapping.remove(typeName);
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -99,8 +110,11 @@ public class PropertyFileBean {
      * was no type mapping with the given name
      */
     public Class<?> getTypeMapping(String typeName) {
-        synchronized (mapping) {
+        try {
+            lock.lock();
             return mapping.get(typeName);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/internal/PropertyFileHandleImpl.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/internal/PropertyFileHandleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.configuration.hub.api.Hub;
 import org.glassfish.hk2.configuration.hub.api.Instance;
@@ -49,7 +50,7 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
     private final static int MAX_TRIES = 10000;
     private final static char SEPARATOR = '.';
     
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private HashMap<TypeData, Map<String, String>> lastRead = new HashMap<TypeData, Map<String, String>>();
     private boolean open = true;
     
@@ -392,7 +393,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             extractData(sFullKey, value, allBeans);
         }
         
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (!open) {
                 throw new IllegalStateException("This handle has been closed");
             }
@@ -422,6 +424,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             }
             
             lastRead = allBeans;
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -476,7 +480,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
      */
     @Override
     public void dispose() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (!open) return;
             open = false;
             
@@ -500,6 +505,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             
             // success or not
             lastRead = allBeans;
+        } finally {
+            lock.unlock();
         }
 
     }

--- a/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/internal/PropertyFileHandleImpl.java
+++ b/hk2-configuration/persistence/property-file/src/main/java/org/glassfish/hk2/configuration/persistence/properties/internal/PropertyFileHandleImpl.java
@@ -393,8 +393,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
             extractData(sFullKey, value, allBeans);
         }
         
+        lock.lock();
         try {
-            lock.lock();
             if (!open) {
                 throw new IllegalStateException("This handle has been closed");
             }
@@ -480,8 +480,8 @@ public class PropertyFileHandleImpl implements PropertyFileHandle {
      */
     @Override
     public void dispose() {
+        lock.lock();
         try {
-            lock.lock();
             if (!open) return;
             open = false;
             

--- a/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Holds information about /META-INF/services and /META-INF/inhabitants for a {@link Module}.
@@ -41,6 +42,7 @@ import java.util.*;
  */
 public final class ModuleMetadata implements Serializable {
 
+    private final ReentrantLock lock = new ReentrantLock();
     /**
      * META-INF/hk2-locator/* cache
      */
@@ -50,16 +52,21 @@ public final class ModuleMetadata implements Serializable {
         return descriptors;
     }
 
-    public synchronized void addDescriptors(String serviceLocatorName, Collection<Descriptor> descriptorsToAdd) {
-        List<Descriptor> descriptorList = descriptors.get(serviceLocatorName);
+    public void addDescriptors(String serviceLocatorName, Collection<Descriptor> descriptorsToAdd) {
+        try {
+            lock.lock();
+            List<Descriptor> descriptorList = descriptors.get(serviceLocatorName);
 
-        if (descriptorList == null) {
-            descriptorList = new ArrayList<Descriptor>();
+            if (descriptorList == null) {
+                descriptorList = new ArrayList<Descriptor>();
 
-            descriptors.put(serviceLocatorName, descriptorList);
+                descriptors.put(serviceLocatorName, descriptorList);
+            }
+
+            descriptorList.addAll(descriptorsToAdd);
+        } finally {
+            lock.unlock();
         }
-
-        descriptorList.addAll(descriptorsToAdd);
     }
 
     public static final class Entry implements Serializable {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/ModuleMetadata.java
@@ -53,8 +53,8 @@ public final class ModuleMetadata implements Serializable {
     }
 
     public void addDescriptors(String serviceLocatorName, Collection<Descriptor> descriptorsToAdd) {
+        lock.lock();
         try {
-            lock.lock();
             List<Descriptor> descriptorList = descriptors.get(serviceLocatorName);
 
             if (descriptorList == null) {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractModulesRegistryImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractModulesRegistryImpl.java
@@ -224,8 +224,8 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param weight int value from 1 to 100 to specify the search order
      */
     public void addRepository(Repository repository, int weight) {
+        lock.lock();
         try {
-            lock.lock();
             // check that we don't already have this repository
             for (Repository repo : repositories.values()) {
                 if (repo.getLocation().equals(repository.getLocation())) {
@@ -248,8 +248,8 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param repository new repository to attach to this registry
      */
     public void addRepository(Repository repository) {
+        lock.lock();
         try {
-            lock.lock();
             repositories.put(100+repositories.size(), repository);
         } finally {
             lock.unlock();
@@ -264,8 +264,8 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param name name of the repository to remove
      */
     public void removeRepository(String name) {
+        lock.lock();
         try {
-            lock.lock();
             for (Integer weight : repositories.keySet()) {
                 Repository repo = repositories.get(weight);
                 if (repo.getName().equals(name)) {
@@ -285,8 +285,8 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @return the repository or null if not found
      */
     public Repository getRepository(String name) {
+        lock.lock();
         try {
-            lock.lock();
             for (Integer weight : repositories.keySet()) {
                 Repository repo = repositories.get(weight);
                 if (repo.getName().equals(name)) {
@@ -560,8 +560,8 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * <code>HK2Module</code> instances.
      */
     public HK2Module add(ModuleDefinition info) throws ResolveError {
+        lock.lock();
         try {
-            lock.lock();
             return add(info, true);
         } finally {
             lock.unlock();

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractModulesRegistryImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractModulesRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
@@ -78,6 +79,7 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
 
     protected final Map<Integer,Repository> repositories = new TreeMap<Integer,Repository>();
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final ConcurrentMap<Class<?>, CopyOnWriteArrayList<?>> runningServices = 
       new ConcurrentHashMap<Class<?>,CopyOnWriteArrayList<?>>();
 
@@ -221,17 +223,22 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param repository new repository to attach to this registry
      * @param weight int value from 1 to 100 to specify the search order
      */
-    public synchronized void addRepository(Repository repository, int weight) {
-        // check that we don't already have this repository
-        for (Repository repo : repositories.values()) {
-            if (repo.getLocation().equals(repository.getLocation())) {
-                throw new RuntimeException("repository at " + repository.getLocation() + " already registered");
+    public void addRepository(Repository repository, int weight) {
+        try {
+            lock.lock();
+            // check that we don't already have this repository
+            for (Repository repo : repositories.values()) {
+                if (repo.getLocation().equals(repository.getLocation())) {
+                    throw new RuntimeException("repository at " + repository.getLocation() + " already registered");
+                }
             }
+            while (repositories.containsKey(weight)) {
+                weight++;
+            }
+            repositories.put(weight, repository);
+        } finally {
+            lock.unlock();
         }
-        while (repositories.containsKey(weight)) {
-            weight++;
-        }
-        repositories.put(weight, repository);
     }
     
     /**
@@ -240,8 +247,13 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * registered in this instance.
      * @param repository new repository to attach to this registry
      */
-    public synchronized void addRepository(Repository repository) {
-        repositories.put(100+repositories.size(), repository);
+    public void addRepository(Repository repository) {
+        try {
+            lock.lock();
+            repositories.put(100+repositories.size(), repository);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -251,13 +263,18 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * longer
      * @param name name of the repository to remove
      */
-    public synchronized void removeRepository(String name) {
-        for (Integer weight : repositories.keySet()) {
-            Repository repo = repositories.get(weight);
-            if (repo.getName().equals(name)) {
-                repositories.remove(weight);
-                return;
+    public void removeRepository(String name) {
+        try {
+            lock.lock();
+            for (Integer weight : repositories.keySet()) {
+                Repository repo = repositories.get(weight);
+                if (repo.getName().equals(name)) {
+                    repositories.remove(weight);
+                    return;
+                }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -267,14 +284,19 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * @param name name of the repository to return
      * @return the repository or null if not found
      */
-    public synchronized Repository getRepository(String name) {
-        for (Integer weight : repositories.keySet()) {
-            Repository repo = repositories.get(weight);
-            if (repo.getName().equals(name)) {
-                return repo;
+    public Repository getRepository(String name) {
+        try {
+            lock.lock();
+            for (Integer weight : repositories.keySet()) {
+                Repository repo = repositories.get(weight);
+                if (repo.getName().equals(name)) {
+                    return repo;
+                }
             }
+            return null;
+        } finally {
+            lock.unlock();
         }
-        return null;
     }
 
     /**
@@ -537,8 +559,13 @@ public abstract class AbstractModulesRegistryImpl implements ModulesRegistry {
      * definition, the registry will be capable of created shared and private
      * <code>HK2Module</code> instances.
      */
-    public synchronized HK2Module add(ModuleDefinition info) throws ResolveError {
-        return add(info, true);
+    public HK2Module add(ModuleDefinition info) throws ResolveError {
+        try {
+            lock.lock();
+            return add(info, true);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public HK2Module add(ModuleDefinition info, boolean resolve) throws ResolveError {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractRepositoryImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractRepositoryImpl.java
@@ -192,8 +192,8 @@ public abstract class AbstractRepositoryImpl implements Repository {
      * @return true if the listener was added successfully
      */
     public boolean addListener(RepositoryChangeListener listener) {
+        lock.lock();
         try {
-            lock.lock();
             if (listeners==null) {
                 listeners = new ArrayList<RepositoryChangeListener>();
             }
@@ -210,8 +210,8 @@ public abstract class AbstractRepositoryImpl implements Repository {
      * @return true if the listener was successfully unregistered
      */
     public boolean removeListener(RepositoryChangeListener listener) {
+        lock.lock();
         try {
-            lock.lock();
             if (listeners==null) {
                 return false;
             }

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractRepositoryImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/AbstractRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import com.sun.enterprise.module.ManifestConstants;
 import java.io.*;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -37,6 +38,7 @@ import java.util.jar.Manifest;
  * @author Sanjeeb.Sahoo@Sun.COM
  */
 public abstract class AbstractRepositoryImpl implements Repository {
+    private final ReentrantLock lock = new ReentrantLock();
     private final String name;
     private final URI location;
     private Map<ModuleId, ModuleDefinition> moduleDefs;
@@ -189,11 +191,16 @@ public abstract class AbstractRepositoryImpl implements Repository {
      * @param listener implementation listening to this repository changes
      * @return true if the listener was added successfully
      */
-    public synchronized boolean addListener(RepositoryChangeListener listener) {
-        if (listeners==null) {
-            listeners = new ArrayList<RepositoryChangeListener>();
+    public boolean addListener(RepositoryChangeListener listener) {
+        try {
+            lock.lock();
+            if (listeners==null) {
+                listeners = new ArrayList<RepositoryChangeListener>();
+            }
+            return listeners.add(listener);
+        } finally {
+            lock.unlock();
         }
-        return listeners.add(listener);
     }
 
     /**
@@ -202,11 +209,16 @@ public abstract class AbstractRepositoryImpl implements Repository {
      * @param listener the previously registered listener
      * @return true if the listener was successfully unregistered
      */
-    public synchronized boolean removeListener(RepositoryChangeListener listener) {
-        if (listeners==null) {
-            return false;
+    public boolean removeListener(RepositoryChangeListener listener) {
+        try {
+            lock.lock();
+            if (listeners==null) {
+                return false;
+            }
+            return listeners.remove(listener);
+        } finally {
+            lock.unlock();
         }
-        return listeners.remove(listener);
     }
 
     /**

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/DirectoryBasedRepository.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/DirectoryBasedRepository.java
@@ -78,8 +78,8 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
 
     @Override
     public boolean addListener(RepositoryChangeListener listener) {
+        lock.lock();
         try {
-            lock.lock();
             final boolean returnValue = super.addListener(listener);
             if (returnValue && timer==null) {
                 initializeSubDirectories();
@@ -89,8 +89,8 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
                     private final ReentrantLock lock = new ReentrantLock();
                     long lastModified = repository.lastModified();
                     public void run() {
+                        lock.lock();
                         try {
-                            lock.lock();
                             if (lastModified<repository.lastModified()) {
                                 lastModified = repository.lastModified();
                                 // something has changed, look into this...
@@ -156,8 +156,8 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
     }
 
     private void directoryChanged() {
+        lock.lock();
         try {
-            lock.lock();
             // not the most efficient implementation, could be revisited later
             HashMap<ModuleId, ModuleDefinition> newModuleDefs =
                     new HashMap<ModuleId, ModuleDefinition>();

--- a/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/DirectoryBasedRepository.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/common_impl/DirectoryBasedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This class is a directory based repository implementation. This mean that all jar
@@ -43,6 +44,7 @@ import java.util.TimerTask;
 public class DirectoryBasedRepository extends AbstractRepositoryImpl {
     
     protected final File repository;
+    private final ReentrantLock lock = new ReentrantLock();
     private final int intervalInMs = Integer.getInteger("hk2.file.directory.changeIntervalTimer", 1000);
     private Timer timer;
     private boolean isTimerThreadDaemon = false;
@@ -75,28 +77,36 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
     }
 
     @Override
-    public synchronized boolean addListener(RepositoryChangeListener listener) {
-
-        final boolean returnValue = super.addListener(listener);
-        if (returnValue && timer==null) {
-            initializeSubDirectories();
-            
-            timer = new Timer("hk2-repo-listener-"+ this.getName(), isTimerThreadDaemon);
-            timer.schedule(new TimerTask() {
-                long lastModified = repository.lastModified();
-                public void run() {
-                    synchronized(this) {
-                        if (lastModified<repository.lastModified()) {
-                            lastModified = repository.lastModified();
-                            // something has changed, look into this...
-                            directoryChanged();
+    public boolean addListener(RepositoryChangeListener listener) {
+        try {
+            lock.lock();
+            final boolean returnValue = super.addListener(listener);
+            if (returnValue && timer==null) {
+                initializeSubDirectories();
+                
+                timer = new Timer("hk2-repo-listener-"+ this.getName(), isTimerThreadDaemon);
+                timer.schedule(new TimerTask() {
+                    private final ReentrantLock lock = new ReentrantLock();
+                    long lastModified = repository.lastModified();
+                    public void run() {
+                        try {
+                            lock.lock();
+                            if (lastModified<repository.lastModified()) {
+                                lastModified = repository.lastModified();
+                                // something has changed, look into this...
+                                directoryChanged();
+                            }
+                        } finally {
+                            lock.unlock();
                         }
                     }
-                }
-            }, intervalInMs, intervalInMs);
-            timer.purge();
+                }, intervalInMs, intervalInMs);
+                timer.purge();
+            }
+            return returnValue; 
+        } finally {
+            lock.unlock();
         }
-        return returnValue;        
     }
 
     @Override
@@ -145,85 +155,89 @@ public class DirectoryBasedRepository extends AbstractRepositoryImpl {
         return disabledFile.exists();
     }
 
-    private synchronized void directoryChanged() {
-
-        // not the most efficient implementation, could be revisited later
-        HashMap<ModuleId, ModuleDefinition> newModuleDefs =
-                new HashMap<ModuleId, ModuleDefinition>();
-        List<URI> libraries = new LinkedList<URI>();
-
+    private void directoryChanged() {
         try {
-            loadModuleDefs(newModuleDefs, libraries);
-        } catch(IOException ioe) {
-            // we probably need to wait until the jar has finished being copied
-            // XXX add some form of retry
-        }
-        for(ModuleDefinition def : newModuleDefs.values()) {
-            if (find(def.getName(), def.getVersion())==null) {
-                add(def);
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.moduleAdded(def);
-                }
+            lock.lock();
+            // not the most efficient implementation, could be revisited later
+            HashMap<ModuleId, ModuleDefinition> newModuleDefs =
+                    new HashMap<ModuleId, ModuleDefinition>();
+            List<URI> libraries = new LinkedList<URI>();
+
+            try {
+                loadModuleDefs(newModuleDefs, libraries);
+            } catch(IOException ioe) {
+                // we probably need to wait until the jar has finished being copied
+                // XXX add some form of retry
             }
-        }
-        for (ModuleDefinition def : findAll()) {
-            if (!newModuleDefs.containsKey(AbstractFactory.getInstance().createModuleId(def))) {
-                remove(def);
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.moduleRemoved(def);
-                }
-            }
-        }
-        List<URI> originalLibraries = super.getJarLocations();
-        for (URI location : libraries) {
-            if (!originalLibraries.contains(location)) {
-                addLibrary(location);
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.added(location);
-                }
-            }
-        }
-        if (originalLibraries.size()>0) {
-            List<URI> copy = new LinkedList<URI>();
-            copy.addAll(originalLibraries);
-            for (URI originalLocation : copy) {
-                if (!libraries.contains(originalLocation)) {
-                    removeLibrary(originalLocation);
+            for(ModuleDefinition def : newModuleDefs.values()) {
+                if (find(def.getName(), def.getVersion())==null) {
+                    add(def);
                     for (RepositoryChangeListener listener : listeners) {
-                        listener.removed(originalLocation);
+                        listener.moduleAdded(def);
                     }
                 }
             }
-        }
+            for (ModuleDefinition def : findAll()) {
+                if (!newModuleDefs.containsKey(AbstractFactory.getInstance().createModuleId(def))) {
+                    remove(def);
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.moduleRemoved(def);
+                    }
+                }
+            }
+            List<URI> originalLibraries = super.getJarLocations();
+            for (URI location : libraries) {
+                if (!originalLibraries.contains(location)) {
+                    addLibrary(location);
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.added(location);
+                    }
+                }
+            }
+            if (originalLibraries.size()>0) {
+                List<URI> copy = new LinkedList<URI>();
+                copy.addAll(originalLibraries);
+                for (URI originalLocation : copy) {
+                    if (!libraries.contains(originalLocation)) {
+                        removeLibrary(originalLocation);
+                        for (RepositoryChangeListener listener : listeners) {
+                            listener.removed(originalLocation);
+                        }
+                    }
+                }
+            }
 
-        // added or removed subdirectories ?
-        List<File> previous = new LinkedList<File>();
-        previous.addAll(subDirectories);
-        for (File file : repository.listFiles(new FileFilter() {
-            public boolean accept(File pathname) {
-                return pathname.isDirectory();
-            }
-        })) {
-            // added ?
-            if (!subDirectories.contains(file)) {
-                for (RepositoryChangeListener listener : listeners) {
-                    listener.added(file.toURI());
+            // added or removed subdirectories ?
+            List<File> previous = new LinkedList<File>();
+            previous.addAll(subDirectories);
+            for (File file : repository.listFiles(new FileFilter() {
+                public boolean accept(File pathname) {
+                    return pathname.isDirectory();
                 }
-                subDirectories.add(file);
-            }  else {
-                // known, removing it from the copied list to check
-                // for removal
-                previous.remove(file);
-            }
-        }
-        // any left in our copy is a removed sub directory.
-        if (!previous.isEmpty()) {
-            for (File file : previous) {
-                 for (RepositoryChangeListener listener : listeners) {
-                    listener.removed(file.toURI());
+            })) {
+                // added ?
+                if (!subDirectories.contains(file)) {
+                    for (RepositoryChangeListener listener : listeners) {
+                        listener.added(file.toURI());
+                    }
+                    subDirectories.add(file);
+                }  else {
+                    // known, removing it from the copied list to check
+                    // for removal
+                    previous.remove(file);
                 }
-                subDirectories.remove(file);
             }
+            // any left in our copy is a removed sub directory.
+            if (!previous.isEmpty()) {
+                for (File file : previous) {
+                     for (RepositoryChangeListener listener : listeners) {
+                        listener.removed(file.toURI());
+                    }
+                    subDirectories.remove(file);
+                }
+            } 
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
@@ -119,8 +119,8 @@ public class ClassLoaderProxy extends URLClassLoader {
      * {@link #findClass(String)} except the classloader punch-in hack.
      */
     /*package*/ Class findClassDirect(String name) throws ClassNotFoundException {
+        lock.lock();
         try {
-            lock.lock();
             Class c = findLoadedClass(name);
             if(c!=null) return c;
             try {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ClassLoaderProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.net.URLClassLoader;
 import java.net.URL;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 import java.io.IOException;
 
 /**
@@ -31,6 +32,7 @@ import java.io.IOException;
  */
 public class ClassLoaderProxy extends URLClassLoader {
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final List<ClassLoader> surrogates = new CopyOnWriteArrayList<ClassLoader>();
     private final List<ClassLoaderFacade> facadeSurrogates = new CopyOnWriteArrayList<ClassLoaderFacade>();
 
@@ -116,13 +118,18 @@ public class ClassLoaderProxy extends URLClassLoader {
     /**
      * {@link #findClass(String)} except the classloader punch-in hack.
      */
-    /*package*/ synchronized Class findClassDirect(String name) throws ClassNotFoundException {
-        Class c = findLoadedClass(name);
-        if(c!=null) return c;
+    /*package*/ Class findClassDirect(String name) throws ClassNotFoundException {
         try {
-            return super.findClass(name);
-        } catch (NoClassDefFoundError e) {
-            throw new ClassNotFoundException(e.getMessage());
+            lock.lock();
+            Class c = findLoadedClass(name);
+            if(c!=null) return c;
+            try {
+                return super.findClass(name);
+            } catch (NoClassDefFoundError e) {
+                throw new ClassNotFoundException(e.getMessage());
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/HK2Factory.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/HK2Factory.java
@@ -33,8 +33,8 @@ public class HK2Factory extends AbstractFactory {
     private static final ReentrantLock lock = new ReentrantLock();
 
     public static void initialize() {
+        lock.lock();
         try {
-            lock.lock();
             if (Instance != null) {
                 LogHelper.getDefaultLogger().fine("Singleton already initialized as " + getInstance());
             }

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/HK2Factory.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/HK2Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,9 @@ import com.sun.enterprise.module.common_impl.AbstractFactory;
 import com.sun.enterprise.module.common_impl.LogHelper;
 import com.sun.enterprise.module.common_impl.ModuleId;
 import com.sun.enterprise.module.ModulesRegistry;
+
+import java.util.concurrent.locks.ReentrantLock;
+
 import com.sun.enterprise.module.ModuleDefinition;
 
 /**
@@ -27,11 +30,18 @@ import com.sun.enterprise.module.ModuleDefinition;
  */
 public class HK2Factory extends AbstractFactory {
 
-    public synchronized static void initialize() {
-        if (Instance != null) {
-            LogHelper.getDefaultLogger().fine("Singleton already initialized as " + getInstance());
+    private static final ReentrantLock lock = new ReentrantLock();
+
+    public static void initialize() {
+        try {
+            lock.lock();
+            if (Instance != null) {
+                LogHelper.getDefaultLogger().fine("Singleton already initialized as " + getInstance());
+            }
+            Instance = new HK2Factory();
+        } finally {
+            lock.unlock();
         }
-        Instance = new HK2Factory();
     }
 
     public ModulesRegistry createModulesRegistry() {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
@@ -60,8 +60,8 @@ final class ModuleClassLoader extends ClassLoaderProxy {
 
 
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        lock.lock();
         try {
-            lock.lock();
             initialize(name);
             return super.loadClass(name, resolve);
         } finally {
@@ -138,8 +138,8 @@ final class ModuleClassLoader extends ClassLoaderProxy {
      */
     private void initialize(String name) {
         if (initialized)    return;
+        lock.lock();
         try {
-            lock.lock();
             if(!initialized) {
                 // if we are preparing, we should just not initiate initialization.
                 if (module.getState().equals(ModuleState.PREPARING)) {

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,8 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
+import java.util.concurrent.locks.ReentrantLock;
+
 import com.sun.enterprise.module.HK2Module;
 
 /**
@@ -35,6 +37,7 @@ import com.sun.enterprise.module.HK2Module;
  */
 final class ModuleClassLoader extends ClassLoaderProxy {
     
+    private final ReentrantLock lock = new ReentrantLock();
     private final ModuleImpl module;
 
     /**
@@ -56,9 +59,14 @@ final class ModuleClassLoader extends ClassLoaderProxy {
     }
 
 
-    protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        initialize(name);
-        return super.loadClass(name, resolve);
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        try {
+            lock.lock();
+            initialize(name);
+            return super.loadClass(name, resolve);
+        } finally {
+            lock.unlock();
+        }
     }
 
     protected Class<?> findClass(String name) throws ClassNotFoundException {
@@ -130,8 +138,8 @@ final class ModuleClassLoader extends ClassLoaderProxy {
      */
     private void initialize(String name) {
         if (initialized)    return;
-
-        synchronized(this) {
+        try {
+            lock.lock();
             if(!initialized) {
                 // if we are preparing, we should just not initiate initialization.
                 if (module.getState().equals(ModuleState.PREPARING)) {
@@ -144,6 +152,8 @@ final class ModuleClassLoader extends ClassLoaderProxy {
                 initializerThread = Thread.currentThread().getStackTrace();
                 initializerClassName = name;
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleImpl.java
@@ -141,8 +141,8 @@ public final class ModuleImpl implements HK2Module {
      */
     /*package*/ ModuleClassLoader getPrivateClassLoader() {
         if (privateCL==null) {
+            lock.lock();
             try {
-                lock.lock();
                 if(privateCL==null) {
                     URI[] locations = moduleDef.getLocations();
                     URL[] urlLocations = new URL[locations.length];
@@ -287,8 +287,8 @@ public final class ModuleImpl implements HK2Module {
      * cannot be satisfied
      */
     public void resolve() throws ResolveError {
+        lock.lock();
         try {
-            lock.lock();
          // already resolved ?
             if (state==ModuleState.ERROR)
                 throw new ResolveError("Module " + getName() + " is in ERROR state");

--- a/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleImpl.java
+++ b/hk2-core/src/main/java/com/sun/enterprise/module/impl/ModuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -68,7 +69,8 @@ import com.sun.enterprise.module.HK2Module;
  * @author Jerome Dochez
  */
 public final class ModuleImpl implements HK2Module {
-    
+
+    private final ReentrantLock lock = new ReentrantLock();
     private final ModuleDefinition moduleDef;
     private WeakReference<ClassLoaderFacade> publicCL;
     private volatile ModuleClassLoader privateCL;
@@ -139,7 +141,8 @@ public final class ModuleImpl implements HK2Module {
      */
     /*package*/ ModuleClassLoader getPrivateClassLoader() {
         if (privateCL==null) {
-            synchronized(this) {
+            try {
+                lock.lock();
                 if(privateCL==null) {
                     URI[] locations = moduleDef.getLocations();
                     URL[] urlLocations = new URL[locations.length];
@@ -161,6 +164,8 @@ public final class ModuleImpl implements HK2Module {
                         }
                     });
                 }
+            } finally {
+                lock.unlock();
             }
         }
         return privateCL;
@@ -281,78 +286,82 @@ public final class ModuleImpl implements HK2Module {
      * @throws com.sun.enterprise.module.ResolveError if any of the declared dependency of this module
      * cannot be satisfied
      */
-    public synchronized void resolve() throws ResolveError {
-        
-        // already resolved ?
-        if (state==ModuleState.ERROR)
-            throw new ResolveError("Module " + getName() + " is in ERROR state");
-        if (state.compareTo(ModuleState.RESOLVED)>=0)
-            return;
+    public void resolve() throws ResolveError {
+        try {
+            lock.lock();
+         // already resolved ?
+            if (state==ModuleState.ERROR)
+                throw new ResolveError("Module " + getName() + " is in ERROR state");
+            if (state.compareTo(ModuleState.RESOLVED)>=0)
+                return;
 
-        if (state==ModuleState.PREPARING) {
-            Utils.identifyCyclicDependency(this, Logger.getAnonymousLogger());
-            throw new ResolveError("Cyclic dependency with " + getName());
-        }
-        state = ModuleState.PREPARING;
-        
-        if (moduleDef.getImportPolicyClassName()!=null) {
-            try {
-                Class<ImportPolicy> importPolicyClass = (Class<ImportPolicy>) getPrivateClassLoader().loadClass(moduleDef.getImportPolicyClassName());
-                ImportPolicy importPolicy = importPolicyClass.newInstance();
-                importPolicy.prepare(this);
-            } catch(ClassNotFoundException e) {
-                state = ModuleState.ERROR;
-                throw new ResolveError(e);
-            } catch(java.lang.InstantiationException e) {
-                state = ModuleState.ERROR;
-                throw new ResolveError(e);
-            } catch(IllegalAccessException e) {
-                state = ModuleState.ERROR;
-                throw new ResolveError(e);
+            if (state==ModuleState.PREPARING) {
+                Utils.identifyCyclicDependency(this, Logger.getAnonymousLogger());
+                throw new ResolveError("Cyclic dependency with " + getName());
             }
-        }
-        for (ModuleDependency dependency : moduleDef.getDependencies()) {
-            ModuleImpl depModule = (ModuleImpl)registry.makeModuleFor(dependency.getName(), dependency.getVersion());
-            if (depModule==null) {
-                state = ModuleState.ERROR;                
-                throw new ResolveError(dependency + " referenced from " 
-                        + moduleDef.getName() + " is not resolved");
+            state = ModuleState.PREPARING;
+            
+            if (moduleDef.getImportPolicyClassName()!=null) {
+                try {
+                    Class<ImportPolicy> importPolicyClass = (Class<ImportPolicy>) getPrivateClassLoader().loadClass(moduleDef.getImportPolicyClassName());
+                    ImportPolicy importPolicy = importPolicyClass.newInstance();
+                    importPolicy.prepare(this);
+                } catch(ClassNotFoundException e) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(e);
+                } catch(java.lang.InstantiationException e) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(e);
+                } catch(IllegalAccessException e) {
+                    state = ModuleState.ERROR;
+                    throw new ResolveError(e);
+                }
+            }
+            for (ModuleDependency dependency : moduleDef.getDependencies()) {
+                ModuleImpl depModule = (ModuleImpl)registry.makeModuleFor(dependency.getName(), dependency.getVersion());
+                if (depModule==null) {
+                    state = ModuleState.ERROR;                
+                    throw new ResolveError(dependency + " referenced from " 
+                            + moduleDef.getName() + " is not resolved");
+                }
+
+                //if (Utils.isLoggable(Level.INFO)) {
+                //    Utils.getDefaultLogger().info("For module" + getName() + " adding new dependent " + module.getName());
+                //}
+                dependencies.add(depModule);
             }
 
-            //if (Utils.isLoggable(Level.INFO)) {
-            //    Utils.getDefaultLogger().info("For module" + getName() + " adding new dependent " + module.getName());
-            //}
-            dependencies.add(depModule);
-        }
+            // once we have proper import/export filtering for modules, we can
+            // build a look-up table to improve performance
 
-        // once we have proper import/export filtering for modules, we can
-        // build a look-up table to improve performance
-
-        // build up the complete list of transitive dependency modules, without any duplication,
-        // in a breadth-first fashion. The reason we do this in breadth-first is to reduce
-        // the search time based on the assumption that classes tend to be discovered in close dependencies. 
-        List<ModuleImpl> transitiveDependencies = new ArrayList<ModuleImpl>();
-        Set<ModuleImpl> transitiveDependenciesSet = new HashSet<ModuleImpl>();
-        LinkedList<ModuleImpl> q = new LinkedList<ModuleImpl>();
-        q.addAll(dependencies);
-        while(!q.isEmpty()) {
-            ModuleImpl m = q.removeFirst();
-            if(transitiveDependenciesSet.add(m)) {
-                // first time visited
-                transitiveDependencies.add(m);
-                m.resolve();
-                q.addAll(m.dependencies);
+            // build up the complete list of transitive dependency modules, without any duplication,
+            // in a breadth-first fashion. The reason we do this in breadth-first is to reduce
+            // the search time based on the assumption that classes tend to be discovered in close dependencies. 
+            List<ModuleImpl> transitiveDependencies = new ArrayList<ModuleImpl>();
+            Set<ModuleImpl> transitiveDependenciesSet = new HashSet<ModuleImpl>();
+            LinkedList<ModuleImpl> q = new LinkedList<ModuleImpl>();
+            q.addAll(dependencies);
+            while(!q.isEmpty()) {
+                ModuleImpl m = q.removeFirst();
+                if(transitiveDependenciesSet.add(m)) {
+                    // first time visited
+                    transitiveDependencies.add(m);
+                    m.resolve();
+                    q.addAll(m.dependencies);
+                }
             }
-        }
 
-        for (ModuleImpl m : transitiveDependencies) {
-            getPrivateClassLoader().addDelegate(m.getClassLoader());
-        }
+            for (ModuleImpl m : transitiveDependencies) {
+                getPrivateClassLoader().addDelegate(m.getClassLoader());
+            }
 
-        //Logger.global.info("HK2Module " + getName() + " resolved");
-        state = ModuleState.RESOLVED;
-        for (ModuleLifecycleListener l : registry.getLifecycleListeners()) {
-            l.moduleResolved(this);
+            //Logger.global.info("HK2Module " + getName() + " resolved");
+            state = ModuleState.RESOLVED;
+            for (ModuleLifecycleListener l : registry.getLifecycleListeners()) {
+                l.moduleResolved(this);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/hk2bridge/internal/CrossOverDescriptor.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/hk2bridge/internal/CrossOverDescriptor.java
@@ -70,8 +70,8 @@ public class CrossOverDescriptor<T> extends AbstractActiveDescriptor<T> {
     }
     
     private void checkState() {
+        lock.lock();
         try {
-            lock.lock();
             if (remoteReified) return;
             remoteReified = true;
             

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
@@ -141,7 +141,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             // retVal is null, and this is not an explicit null, so must actually do the creation
             while (creating.contains(activeDescriptor)) {
                 try {
-                    this.wait();
+                    // FIXME Find other way to replace wait()
+                    Thread.sleep(1);
                 }
                 catch (InterruptedException e) {
                     throw new RuntimeException(e);
@@ -180,7 +181,6 @@ public abstract class OperationContext<T extends Annotation> implements Context<
                 }
                 
                 creating.remove(activeDescriptor);
-                this.notifyAll();
             } finally {
                 lock.unlock();
             }

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/OperationContext.java
@@ -81,8 +81,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         LinkedList<OperationHandleImpl<T>> closingOperationStack;
         boolean closingOperation;
         
+        lock.lock();
         try {
-            lock.lock();
             localManager = manager;
             closingOperationStack = closingOperations.get(Thread.currentThread().getId());
             closingOperation = (closingOperationStack != null && !closingOperationStack.isEmpty());
@@ -97,8 +97,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         
         OperationHandleImpl<T> operation = localManager.getCurrentOperationOnThisThread();
         if (operation == null) {
+            lock.lock();
             try {
-                lock.lock();
                 if (!closingOperation) {
                     throw new IllegalStateException("There is no current operation of type " +
                             getScope().getName() + " on thread " + Thread.currentThread().getId());
@@ -111,8 +111,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         }
         
         LinkedHashMap<ActiveDescriptor<?>, Object> serviceMap;
+        lock.lock();
         try {
-            lock.lock();
             serviceMap = operationMap.get(operation);
             if (serviceMap == null) {
                 if (closingOperation || shuttingDown) {
@@ -174,8 +174,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             success = true;
         }
         finally {
+            lock.lock();
             try {
-                lock.lock();
                 if (success) {
                     serviceMap.put(activeDescriptor, retVal);
                 }
@@ -195,8 +195,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
     @Override
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
         SingleOperationManager<T> localManager;
+        lock.lock();
         try {
-            lock.lock();
             localManager = manager;
         } finally {
             lock.unlock();
@@ -206,8 +206,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         OperationHandleImpl<T> operation = localManager.getCurrentOperationOnThisThread();
         if (operation == null) return false;
         
+        lock.lock();
         try {
-            lock.lock();
             HashMap<ActiveDescriptor<?>, Object> serviceMap;
             
             serviceMap = operationMap.get(operation);
@@ -226,8 +226,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
     @SuppressWarnings("unchecked")
     @Override
     public void destroyOne(ActiveDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             for (HashMap<ActiveDescriptor<?>, Object> serviceMap : operationMap.values()) {
                 Object killMe = serviceMap.remove(descriptor);
                 if (killMe == null) continue;
@@ -245,8 +245,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
         HashMap<ActiveDescriptor<?>, Object> serviceMap;
         LinkedList<OperationHandleImpl<T>> stack;
         
+        lock.lock();
         try {
-            lock.lock();
             stack = closingOperations.get(tid);
             if (stack == null) {
                 stack = new LinkedList<OperationHandleImpl<T>>();
@@ -284,8 +284,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             }
         }
         finally {
+            lock.lock();
             try {
-                lock.lock();
                 operationMap.remove(operation);
             
                 stack.removeFirst();
@@ -304,8 +304,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
     @Override
     public void shutdown() {
         Set<OperationHandleImpl<T>> toShutDown;
+        lock.lock();
         try {
-            lock.lock();
             shuttingDown = true;
             toShutDown = operationMap.keySet();
         } finally {
@@ -318,8 +318,8 @@ public abstract class OperationContext<T extends Annotation> implements Context<
             }
         }
         finally {
+            lock.lock();
             try {
-                lock.lock();
                 operationMap.clear();
             } finally {
                 lock.unlock();

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationHandleImpl.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationHandleImpl.java
@@ -67,8 +67,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public OperationState getState() {
+        operationLock.lock();
         try {
-            operationLock.lock();
             return state;
         } finally {
             operationLock.unlock();
@@ -83,8 +83,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
     }
     
     private void checkState() {
+        operationLock.lock();
         try {
-            operationLock.lock();
             if (OperationState.CLOSED.equals(state)) {
                 throw new IllegalStateException(this + " is closed");
             }
@@ -98,8 +98,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public Set<Long> getActiveThreads() {
+        operationLock.lock();
         try {
-            operationLock.lock();
             return Collections.unmodifiableSet(activeThreads);
         } finally {
             operationLock.unlock();
@@ -111,8 +111,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public void suspend(long threadId) {
+        operationLock.lock();
         try {
-            operationLock.lock();
             if (OperationState.CLOSED.equals(state)) return;
             
             parent.disassociateThread(threadId, this);
@@ -141,8 +141,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public void resume(long threadId) throws IllegalStateException {
+        operationLock.lock();
         try {
-            operationLock.lock();
             checkState();
             
             if (activeThreads.contains(threadId)) return;
@@ -181,8 +181,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
         // outside the lock
         parent.disposeAllOperationServices(this);
         
+        operationLock.lock();
         try {
-            operationLock.lock();
             for (long threadId : activeThreads) {
                 parent.disassociateThread(threadId, this);
             }
@@ -207,8 +207,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public Object getOperationData() {
+        lock.lock();
         try {
-            lock.lock();
             return userData;
         } finally {
             lock.unlock();
@@ -220,8 +220,8 @@ public class OperationHandleImpl<T extends Annotation> implements OperationHandl
      */
     @Override
     public void setOperationData(Object data) {
+        lock.lock();
         try {
-            lock.lock();
             userData = data;
         } finally {
             lock.unlock();

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationManagerImpl.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/OperationManagerImpl.java
@@ -49,8 +49,8 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public <T extends Annotation> OperationHandle<T> createOperation(T scope) {
         SingleOperationManager<T> manager;
+        lock.lock();
         try {
-            lock.lock();
             manager = (SingleOperationManager<T>) children.get(scope.annotationType());
         
             if (manager == null) {
@@ -82,8 +82,8 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public <T extends Annotation> Set<OperationHandle<T>> getCurrentOperations(T scope) {
         SingleOperationManager<T> manager;
+        lock.lock();
         try {
-            lock.lock();
             manager = (SingleOperationManager<T>) children.get(scope.annotationType());
             if (manager == null) return Collections.emptySet();
         } finally {
@@ -100,8 +100,8 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public <T extends Annotation> OperationHandle<T> getCurrentOperation(T scope) {
         SingleOperationManager<T> manager;
+        lock.lock();
         try {
-            lock.lock();
             manager = (SingleOperationManager<T>) children.get(scope.annotationType());
             if (manager == null) return null;  
         } finally {
@@ -117,8 +117,8 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public void shutdownAllOperations(Annotation scope) {
         SingleOperationManager<?> manager;
+        lock.lock();
         try {
-            lock.lock();
             manager = children.remove(scope.annotationType());
             if (manager == null) return;
             

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/SingleOperationManager.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/SingleOperationManager.java
@@ -81,8 +81,8 @@ public class SingleOperationManager<T extends Annotation> {
     
     public OperationHandleImpl<T> createOperation() {
         
+        operationLock.lock();
         try {
-            operationLock.lock();
             if (closed) {
                 throw new IllegalStateException("This manager has been closed");
             }
@@ -156,8 +156,8 @@ public class SingleOperationManager<T extends Annotation> {
     public OperationHandleImpl<T> getCurrentOperationOnThisThread() {
         long threadId = Thread.currentThread().getId();
         
+        operationLock.lock();
         try {
-            operationLock.lock();
             if (closed) return null;
             return getCurrentOperationOnThisThread(threadId);
         } finally {
@@ -168,8 +168,8 @@ public class SingleOperationManager<T extends Annotation> {
     /* package */ Set<OperationHandle<T>> getAllOperations() {
         HashSet<OperationHandle<T>> retVal = new HashSet<OperationHandle<T>>();
         
+        operationLock.lock();
         try {
-            operationLock.lock();
             if (closed) return Collections.emptySet();
             
             retVal.addAll(openScopes.values());
@@ -181,8 +181,8 @@ public class SingleOperationManager<T extends Annotation> {
     }
     
     /* package */ void shutdown() {
+        operationLock.lock();
         try {
-            operationLock.lock();
             if (closed) return;
             closed = true;
             

--- a/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/SingleOperationManager.java
+++ b/hk2-extras/src/main/java/org/glassfish/hk2/extras/operation/internal/SingleOperationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/DynamicConfigurationImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/DynamicConfigurationImpl.java
@@ -254,8 +254,8 @@ public class DynamicConfigurationImpl implements DynamicConfiguration {
      */
     @Override
     public void commit() throws MultiException {
+        lock.lock();
         try {
-            lock.lock();
             checkState();
             
             committed = true;
@@ -267,8 +267,8 @@ public class DynamicConfigurationImpl implements DynamicConfiguration {
     }
     
     private void checkState() {
+        lock.lock();
         try {
-            lock.lock();
             if (committed) throw new IllegalStateException();
         } finally {
             lock.unlock();

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/IndexedListData.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/IndexedListData.java
@@ -39,8 +39,8 @@ public class IndexedListData {
     public Collection<SystemDescriptor<?>> getSortedList() {
         if (sorted) return unsortedList;
         
+        lock.lock();
         try {
-            lock.lock();
             if (sorted) return unsortedList;
         
             if (unsortedList.size() <= 1) {
@@ -58,8 +58,8 @@ public class IndexedListData {
     }
     
     public void addDescriptor(SystemDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             unsortedList.add(descriptor);
             
             if (unsortedList.size() > 1) {
@@ -76,8 +76,8 @@ public class IndexedListData {
     }
     
     public void removeDescriptor(SystemDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             ListIterator<SystemDescriptor<?>> iterator = unsortedList.listIterator();
             while (iterator.hasNext()) {
                 SystemDescriptor<?> candidate = iterator.next();
@@ -101,8 +101,8 @@ public class IndexedListData {
     }
     
     public boolean isEmpty() {
+        lock.lock();
         try {
-            lock.lock();
             return unsortedList.isEmpty();
         } finally {
             lock.unlock();
@@ -113,8 +113,8 @@ public class IndexedListData {
      * Called by a SystemDescriptor when its ranking has changed
      */
     public void unSort() {
+        lock.lock();
         try {
-            lock.lock();
             if (unsortedList.size() > 1) {
                 sorted = false;
             }
@@ -124,8 +124,8 @@ public class IndexedListData {
     }
     
     public void clear() {
+        lock.lock();
         try {
-            lock.lock();
             for (SystemDescriptor<?> descriptor : unsortedList) {
                 descriptor.removeList(this);
             }
@@ -137,8 +137,8 @@ public class IndexedListData {
     }
     
     public int size() {
+        lock.lock();
         try {
-            lock.lock();
             return unsortedList.size();
         } finally {
             lock.unlock();

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/InstantiationServiceImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/InstantiationServiceImpl.java
@@ -40,8 +40,8 @@ public class InstantiationServiceImpl implements InstantiationService {
      */
     @Override
     public InstantiationData getInstantiationData() {
+        lock.lock();
         try {
-            lock.lock();
             long tid = Thread.currentThread().getId();
             
             LinkedList<Injectee> threadStack = injecteeStack.get(tid);
@@ -70,8 +70,8 @@ public class InstantiationServiceImpl implements InstantiationService {
     }
     
     public void pushInjecteeParent(Injectee injectee) {
+        lock.lock();
         try {
-            lock.lock();
             long tid = Thread.currentThread().getId();
             
             LinkedList<Injectee> threadStack = injecteeStack.get(tid);
@@ -87,8 +87,8 @@ public class InstantiationServiceImpl implements InstantiationService {
     }
     
     public void popInjecteeParent() {
+        lock.lock();
         try {
-            lock.lock();
             long tid = Thread.currentThread().getId();
             
             LinkedList<Injectee> threadStack = injecteeStack.get(tid);

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/PerLocatorUtilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/PerLocatorUtilities.java
@@ -259,8 +259,8 @@ public class PerLocatorUtilities {
     }
     
     public void releaseCaches() {
+        lock.lock();
         try {
-            lock.lock();
             hasInjectCache.removeAll();
             if (proxyUtilities != null) {
                 proxyUtilities.releaseCache();
@@ -280,8 +280,8 @@ public class PerLocatorUtilities {
     public ProxyUtilities getProxyUtilities() {
         if (proxyUtilities != null) return proxyUtilities;
         
+        lock.lock();
         try {
-            lock.lock();
             if (proxyUtilities != null) return proxyUtilities;
             
             proxyUtilities = new ProxyUtilities();

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/PerLocatorUtilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/PerLocatorUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.WeakHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 
@@ -39,6 +40,7 @@ import org.jvnet.hk2.annotations.Service;
  *
  */
 public class PerLocatorUtilities {
+    private final ReentrantLock lock = new ReentrantLock();
     /** Must not be static, otherwise it can leak when using thread pools */
     private final Hk2ThreadLocal<WeakHashMap<Class<?>, String>> threadLocalAutoAnalyzerNameCache =
             new Hk2ThreadLocal<WeakHashMap<Class<?>, String>>() {
@@ -256,10 +258,15 @@ public class PerLocatorUtilities {
         return hard;
     }
     
-    public synchronized void releaseCaches() {
-        hasInjectCache.removeAll();
-        if (proxyUtilities != null) {
-            proxyUtilities.releaseCache();
+    public void releaseCaches() {
+        try {
+            lock.lock();
+            hasInjectCache.removeAll();
+            if (proxyUtilities != null) {
+                proxyUtilities.releaseCache();
+            }
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -273,12 +280,15 @@ public class PerLocatorUtilities {
     public ProxyUtilities getProxyUtilities() {
         if (proxyUtilities != null) return proxyUtilities;
         
-        synchronized (this) {
+        try {
+            lock.lock();
             if (proxyUtilities != null) return proxyUtilities;
             
             proxyUtilities = new ProxyUtilities();
             
             return proxyUtilities;
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ProxyUtilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ProxyUtilities.java
@@ -92,8 +92,8 @@ public class ProxyUtilities {
         });
         
         DelegatingClassLoader initDelegatingLoader;
+        lock.lock();
         try {
-            lock.lock();
             initDelegatingLoader = superClassToDelegator.get(loader);
             if (initDelegatingLoader == null) {
                 initDelegatingLoader = AccessController.doPrivileged(new PrivilegedAction<DelegatingClassLoader>() {
@@ -135,8 +135,8 @@ public class ProxyUtilities {
             @SuppressWarnings("unchecked")
             @Override
             public T run() {
+                proxyCreationLock.lock();
                 try {
-                    proxyCreationLock.lock();
                     ProxyFactory.ClassLoaderProvider originalProvider = ProxyFactory.classLoaderProvider;
                     ProxyFactory.classLoaderProvider = new ProxyFactory.ClassLoaderProvider() {
                         
@@ -225,8 +225,8 @@ public class ProxyUtilities {
     }
     
     public void releaseCache() {
+        lock.lock();
         try {
-            lock.lock();
             superClassToDelegator.clear();
         } finally {
             lock.unlock();

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceHandleImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceHandleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Context;
@@ -42,7 +43,7 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     private ActiveDescriptor<T> root;
     private final ServiceLocatorImpl locator;
     private final LinkedList<Injectee> injectees = new LinkedList<Injectee>();
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     
     private boolean serviceDestroyed = false;
     private boolean serviceSet = false;
@@ -68,8 +69,11 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     }
     
     private Injectee getLastInjectee() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return (injectees.isEmpty()) ? null : injectees.getLast() ;
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -81,7 +85,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             }
         }
         
-        synchronized (lock) {
+        try {
+            lock.lock();
             if (serviceDestroyed) throw new IllegalStateException("Service has been disposed");
             
             if (serviceSet) return service;
@@ -95,6 +100,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             serviceSet = true;
         
             return service;
+        } finally {
+            lock.unlock();
         }
         
     }
@@ -136,7 +143,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
         if (!root.isReified()) return;
         
         List<ServiceHandleImpl<?>> localSubHandles;
-        synchronized (lock) {
+        try {
+            lock.lock();
             serviceActive = isActive();
             
             if (serviceDestroyed) return;
@@ -146,6 +154,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             
             localSubHandles = new ArrayList<ServiceHandleImpl<?>>(subHandles);
             subHandles.clear();
+        } finally {
+            lock.unlock();
         }
         
         if (root.getScopeAnnotation().equals(PerLookup.class)) {
@@ -175,35 +185,50 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     
     @Override
     public void setServiceData(Object serviceData) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             this.serviceData = serviceData;
+        } finally {
+            lock.unlock();
         }
         
     }
 
     @Override
     public Object getServiceData() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return serviceData;
+        } finally {
+            lock.unlock();
         }
     }
     
     @Override
     public List<ServiceHandle<?>> getSubHandles() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             return new ArrayList<ServiceHandle<?>>(subHandles);
+        } finally {
+            lock.unlock();
         }
     }
     
     public void pushInjectee(Injectee push) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             injectees.add(push);
+        } finally {
+            lock.unlock();
         }
     }
     
     public void popInjectee() {
-        synchronized (lock) {
+        try {
+            lock.lock();
             injectees.removeLast();
+        } finally {
+            lock.unlock();
         }
     }
     
@@ -213,8 +238,11 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
      * @param subHandle A handle to add for proper destruction
      */
     public void addSubHandle(ServiceHandleImpl<?> subHandle) {
-        synchronized (lock) {
+        try {
+            lock.lock();
             subHandles.add(subHandle);
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceHandleImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceHandleImpl.java
@@ -69,8 +69,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     }
     
     private Injectee getLastInjectee() {
+        lock.lock();
         try {
-            lock.lock();
             return (injectees.isEmpty()) ? null : injectees.getLast() ;
         } finally {
             lock.unlock();
@@ -85,8 +85,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
             }
         }
         
+        lock.lock();
         try {
-            lock.lock();
             if (serviceDestroyed) throw new IllegalStateException("Service has been disposed");
             
             if (serviceSet) return service;
@@ -143,8 +143,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
         if (!root.isReified()) return;
         
         List<ServiceHandleImpl<?>> localSubHandles;
+        lock.lock();
         try {
-            lock.lock();
             serviceActive = isActive();
             
             if (serviceDestroyed) return;
@@ -185,8 +185,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     
     @Override
     public void setServiceData(Object serviceData) {
+        lock.lock();
         try {
-            lock.lock();
             this.serviceData = serviceData;
         } finally {
             lock.unlock();
@@ -196,8 +196,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
 
     @Override
     public Object getServiceData() {
+        lock.lock();
         try {
-            lock.lock();
             return serviceData;
         } finally {
             lock.unlock();
@@ -206,8 +206,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     
     @Override
     public List<ServiceHandle<?>> getSubHandles() {
+        lock.lock();
         try {
-            lock.lock();
             return new ArrayList<ServiceHandle<?>>(subHandles);
         } finally {
             lock.unlock();
@@ -215,8 +215,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     }
     
     public void pushInjectee(Injectee push) {
+        lock.lock();
         try {
-            lock.lock();
             injectees.add(push);
         } finally {
             lock.unlock();
@@ -224,8 +224,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
     }
     
     public void popInjectee() {
+        lock.lock();
         try {
-            lock.lock();
             injectees.removeLast();
         } finally {
             lock.unlock();
@@ -238,8 +238,8 @@ public class ServiceHandleImpl<T> implements ServiceHandle<T> {
      * @param subHandle A handle to add for proper destruction
      */
     public void addSubHandle(ServiceHandleImpl<?> subHandle) {
+        lock.lock();
         try {
-            lock.lock();
             subHandles.add(subHandle);
         } finally {
             lock.unlock();

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -193,8 +193,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private ServiceLocatorState state = ServiceLocatorState.RUNNING;
 
     private static long getAndIncrementLocatorId() {
+       sLock.lock();
        try {
-           sLock.lock();
             return currentLocatorId++;
         } finally {
             sLock.unlock();
@@ -879,8 +879,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
         try {
             if (state.equals(ServiceLocatorState.SHUTDOWN)) return;
 
+            childrenLock.lock();
             try {
-                childrenLock.lock();
                 for (Iterator<ServiceLocatorImpl> childIterator = children.keySet().iterator(); childIterator.hasNext();) {
                     ServiceLocatorImpl child = childIterator.next();
                     childIterator.remove();
@@ -945,8 +945,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
             contextCache.clear();
             perLocatorUtilities.shutdown();
             
+            childrenLock.lock();
             try {
-                childrenLock.lock();
                 children.clear();
             } finally {
                 childrenLock.unlock();
@@ -1956,8 +1956,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
             }
         }
 
+        allResolversLock.lock();
         try {
-            allResolversLock.lock();
             allResolvers.clear();
             allResolvers.putAll(newResolvers);
         } finally {
@@ -2001,8 +2001,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private void reupClassAnalyzers() {
         List<ServiceHandle<?>> allAnalyzers = protectedGetAllServiceHandles(ClassAnalyzer.class);
 
+        classAnalyzerLock.lock();
         try {
-            classAnalyzerLock.lock();
             classAnalyzers.clear();
 
             for (ServiceHandle<?> handle : allAnalyzers) {
@@ -2088,8 +2088,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     private void getAllChildren(LinkedList<ServiceLocatorImpl> allMyChildren) {
         LinkedList<ServiceLocatorImpl> addMe;
+        childrenLock.lock();
         try {
-            childrenLock.lock();
             addMe = new LinkedList<ServiceLocatorImpl>(children.keySet());
         } finally {
             childrenLock.unlock();
@@ -2389,8 +2389,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
     }
 
     private void addChild(ServiceLocatorImpl child) {
+        childrenLock.lock();
         try {
-            childrenLock.lock();
             children.put(child, null);
         } finally {
             childrenLock.unlock();
@@ -2398,8 +2398,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
     }
 
     private void removeChild(ServiceLocatorImpl child) {
+        childrenLock.lock();
         try {
-            childrenLock.lock();
             children.remove(child);
         } finally {
             childrenLock.unlock();
@@ -2425,8 +2425,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     @Override
     public String getDefaultClassAnalyzerName() {
+        classAnalyzerLock.lock();
         try {
-            classAnalyzerLock.lock();
             return defaultClassAnalyzer;
         } finally {
             classAnalyzerLock.unlock();
@@ -2435,8 +2435,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     @Override
     public void setDefaultClassAnalyzerName(String defaultClassAnalyzer) {
+        classAnalyzerLock.lock();
         try {
-            classAnalyzerLock.lock();
             if (defaultClassAnalyzer == null) {
                 this.defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
             }
@@ -2473,8 +2473,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     /* package */ ClassAnalyzer getAnalyzer(String name, Collector collector) {
         ClassAnalyzer retVal;
+        classAnalyzerLock.lock();
         try {
-            classAnalyzerLock.lock();
             if (name == null) {
                 name = defaultClassAnalyzer ;
             }

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/ServiceLocatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,6 +44,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -124,7 +125,7 @@ public class ServiceLocatorImpl implements ServiceLocator {
     });
 
     private final static int CACHE_SIZE = 20000;
-    private final static Object sLock = new Object();
+    private final static ReentrantLock sLock = new ReentrantLock();
     private static long currentLocatorId = 0L;
 
     /* package */ final static DescriptorComparator DESCRIPTOR_COMPARATOR = new DescriptorComparator();
@@ -166,15 +167,17 @@ public class ServiceLocatorImpl implements ServiceLocator {
             return _resolveContext(a);
         }
     });
+    private final ReentrantLock childrenLock = new ReentrantLock();
     private final Map<ServiceLocatorImpl, ServiceLocatorImpl> children =
             new WeakHashMap<ServiceLocatorImpl, ServiceLocatorImpl>(); // Must be Weak for throw away children
 
-    private final Object classAnalyzerLock = new Object();
+    private final ReentrantLock classAnalyzerLock = new ReentrantLock();
     private final HashMap<String, ClassAnalyzer> classAnalyzers =
             new HashMap<String, ClassAnalyzer>();
     private String defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
     private volatile Unqualified defaultUnqualified = null;
 
+    private final ReentrantLock allResolversLock = new ReentrantLock();
     private ConcurrentHashMap<Class<? extends Annotation>, InjectionResolver<?>> allResolvers =
             new ConcurrentHashMap<Class<? extends Annotation>, InjectionResolver<?>>();
     private final Cache<SystemInjecteeImpl, InjectionResolver<?>> injecteeToResolverCache = 
@@ -190,8 +193,11 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private ServiceLocatorState state = ServiceLocatorState.RUNNING;
 
     private static long getAndIncrementLocatorId() {
-        synchronized (sLock) {
+       try {
+           sLock.lock();
             return currentLocatorId++;
+        } finally {
+            sLock.unlock();
         }
     }
 
@@ -873,12 +879,15 @@ public class ServiceLocatorImpl implements ServiceLocator {
         try {
             if (state.equals(ServiceLocatorState.SHUTDOWN)) return;
 
-            synchronized(children) {
+            try {
+                childrenLock.lock();
                 for (Iterator<ServiceLocatorImpl> childIterator = children.keySet().iterator(); childIterator.hasNext();) {
                     ServiceLocatorImpl child = childIterator.next();
                     childIterator.remove();
                     child.shutdown();
                 }
+            } finally {
+                childrenLock.unlock();
             }
 
             if (parent != null) {
@@ -936,8 +945,11 @@ public class ServiceLocatorImpl implements ServiceLocator {
             contextCache.clear();
             perLocatorUtilities.shutdown();
             
-            synchronized (children) {
+            try {
+                childrenLock.lock();
                 children.clear();
+            } finally {
+                childrenLock.unlock();
             }
 
             Logger.getLogger().debug("Shutdown ServiceLocator " + this);
@@ -1944,9 +1956,12 @@ public class ServiceLocatorImpl implements ServiceLocator {
             }
         }
 
-        synchronized (allResolvers) {
+        try {
+            allResolversLock.lock();
             allResolvers.clear();
             allResolvers.putAll(newResolvers);
+        } finally {
+            allResolversLock.unlock();
         }
         injecteeToResolverCache.clear();
     }
@@ -1986,7 +2001,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
     private void reupClassAnalyzers() {
         List<ServiceHandle<?>> allAnalyzers = protectedGetAllServiceHandles(ClassAnalyzer.class);
 
-        synchronized (classAnalyzerLock) {
+        try {
+            classAnalyzerLock.lock();
             classAnalyzers.clear();
 
             for (ServiceHandle<?> handle : allAnalyzers) {
@@ -1999,6 +2015,8 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
                 classAnalyzers.put(name, created);
             }
+        } finally {
+            classAnalyzerLock.unlock();
         }
     }
 
@@ -2070,8 +2088,11 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     private void getAllChildren(LinkedList<ServiceLocatorImpl> allMyChildren) {
         LinkedList<ServiceLocatorImpl> addMe;
-        synchronized (children) {
+        try {
+            childrenLock.lock();
             addMe = new LinkedList<ServiceLocatorImpl>(children.keySet());
+        } finally {
+            childrenLock.unlock();
         }
 
         allMyChildren.addAll(addMe);
@@ -2368,14 +2389,20 @@ public class ServiceLocatorImpl implements ServiceLocator {
     }
 
     private void addChild(ServiceLocatorImpl child) {
-        synchronized (children) {
+        try {
+            childrenLock.lock();
             children.put(child, null);
+        } finally {
+            childrenLock.unlock();
         }
     }
 
     private void removeChild(ServiceLocatorImpl child) {
-        synchronized (children) {
+        try {
+            childrenLock.lock();
             children.remove(child);
+        } finally {
+            childrenLock.unlock();
         }
     }
 
@@ -2398,20 +2425,26 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     @Override
     public String getDefaultClassAnalyzerName() {
-        synchronized (classAnalyzerLock) {
+        try {
+            classAnalyzerLock.lock();
             return defaultClassAnalyzer;
+        } finally {
+            classAnalyzerLock.unlock();
         }
     }
 
     @Override
     public void setDefaultClassAnalyzerName(String defaultClassAnalyzer) {
-        synchronized (classAnalyzerLock) {
+        try {
+            classAnalyzerLock.lock();
             if (defaultClassAnalyzer == null) {
                 this.defaultClassAnalyzer = ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME;
             }
             else {
                 this.defaultClassAnalyzer = defaultClassAnalyzer;
             }
+        } finally {
+            classAnalyzerLock.unlock();
         }
     }
     
@@ -2440,12 +2473,15 @@ public class ServiceLocatorImpl implements ServiceLocator {
 
     /* package */ ClassAnalyzer getAnalyzer(String name, Collector collector) {
         ClassAnalyzer retVal;
-        synchronized (classAnalyzerLock) {
+        try {
+            classAnalyzerLock.lock();
             if (name == null) {
                 name = defaultClassAnalyzer ;
             }
 
             retVal = classAnalyzers.get(name);
+        } finally {
+            classAnalyzerLock.unlock();
         }
 
         if (retVal == null) {

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/SingletonContext.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/SingletonContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Singleton;
 
@@ -41,6 +42,7 @@ import org.glassfish.hk2.utilities.reflection.Logger;
 @Singleton
 public class SingletonContext implements Context<Singleton> {
     private int generationNumber = Integer.MIN_VALUE;
+    private final ReentrantLock lock = new ReentrantLock();
     private final ServiceLocatorImpl locator;
 
     private final Cache<ContextualInput<Object>, Object> valueCache =
@@ -144,8 +146,11 @@ public class SingletonContext implements Context<Singleton> {
         for (ActiveDescriptor<?> one : all) {
             if (one.getScope() == null || !one.getScope().equals(Singleton.class.getName())) continue;
 
-            synchronized (this) {
+            try {
+                lock.lock();
                 if (one.getCache() == null) continue;
+            } finally {
+                lock.unlock();
             }
 
             if (one.getLocatorId() == null || one.getLocatorId().longValue() != myLocatorId) continue;

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/SingletonContext.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/SingletonContext.java
@@ -146,8 +146,8 @@ public class SingletonContext implements Context<Singleton> {
         for (ActiveDescriptor<?> one : all) {
             if (one.getScope() == null || !one.getScope().equals(Singleton.class.getName())) continue;
 
+            lock.lock();
             try {
-                lock.lock();
                 if (one.getCache() == null) continue;
             } finally {
                 lock.unlock();

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/SystemDescriptor.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/SystemDescriptor.java
@@ -290,8 +290,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
      */
     @Override
     public void setCache(T cacheMe) {
+        cacheLock.lock();
         try {
-            cacheLock.lock();
             cachedValue = cacheMe;
             cacheSet = true;
         } finally {
@@ -304,8 +304,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
      */
     @Override
     public void releaseCache() {
+        cacheLock.lock();
         try {
-            cacheLock.lock();
             cacheSet = false;
             cachedValue = null;
         } finally {
@@ -322,8 +322,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
         // reified it is never un-reified
         if (reified) return true;
 
+        lock.lock();
         try {
-            lock.lock();
             return reified;
         } finally {
             lock.unlock();
@@ -561,8 +561,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
     private void checkState() {
         if (reified) return;
 
+        lock.lock();
         try {
-            lock.lock();
             if (!reified) throw new IllegalStateException();
         } finally {
             lock.unlock();
@@ -659,8 +659,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
     /* package */ void reify(Class<?> implClass, Collector collector) {
         if (reified) return;
 
+        lock.lock();
         try {
-            lock.lock();
             if (reified) return;
 
             while (reifying) {
@@ -687,8 +687,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
             internalReify(implClass, collector);
         }
         finally {
+            lock.lock();
             try {
-                lock.lock();
                 reifying = false;
                 notReifyingCondition.signalAll();
 
@@ -837,8 +837,8 @@ public class SystemDescriptor<T> implements ActiveDescriptor<T>, Closeable {
     public boolean close() {
         if (closed) return true;
         
+        lock.lock();
         try {
-            lock.lock();
             if (closed) return true;
             
             closed = true;

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -109,6 +110,7 @@ import org.jvnet.hk2.annotations.Service;
  */
 public class Utilities {
     private final static String USE_SOFT_REFERENCE_PROPERTY = "org.jvnet.hk2.properties.useSoftReference";
+    private final static ReentrantLock lock = new ReentrantLock();
     final static boolean USE_SOFT_REFERENCE;
     static {
         USE_SOFT_REFERENCE = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
@@ -2254,24 +2256,29 @@ public class Utilities {
      * 
      * @return true if the system can create proxies, false otherwise
      */
-    public synchronized static boolean proxiesAvailable() {
-        if (proxiesAvailable != null) {
-            return proxiesAvailable;
-        }
-        
-        ClassLoader loader = Utilities.class.getClassLoader();
-        if (loader == null) {
-            loader = ClassLoader.getSystemClassLoader();
-        }
-        
+    public static boolean proxiesAvailable() {
         try {
-            loader.loadClass("javassist.util.proxy.MethodHandler");
-            proxiesAvailable = true;
-            return true;
-        }
-        catch (Throwable th) {
-            proxiesAvailable = false;
-            return false;
+            lock.lock();
+            if (proxiesAvailable != null) {
+                return proxiesAvailable;
+            }
+            
+            ClassLoader loader = Utilities.class.getClassLoader();
+            if (loader == null) {
+                loader = ClassLoader.getSystemClassLoader();
+            }
+            
+            try {
+                loader.loadClass("javassist.util.proxy.MethodHandler");
+                proxiesAvailable = true;
+                return true;
+            }
+            catch (Throwable th) {
+                proxiesAvailable = false;
+                return false;
+            }
+        } finally {
+            lock.unlock();
         }
     }
     

--- a/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
+++ b/hk2-locator/src/main/java/org/jvnet/hk2/internal/Utilities.java
@@ -2257,8 +2257,8 @@ public class Utilities {
      * @return true if the system can create proxies, false otherwise
      */
     public static boolean proxiesAvailable() {
+        lock.lock();
         try {
-            lock.lock();
             if (proxiesAvailable != null) {
                 return proxiesAvailable;
             }

--- a/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/AsyncRunLevelContext.java
+++ b/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/AsyncRunLevelContext.java
@@ -163,8 +163,8 @@ public class AsyncRunLevelContext {
         Integer localModeOverride;
         long tid = -1L;
         
+        lock.lock();
         try {
-            lock.lock();
             localModeOverride = modeOverride;
             
             retVal = (U) backingMap.get(activeDescriptor);
@@ -315,8 +315,8 @@ public class AsyncRunLevelContext {
             throw new RuntimeException(th);
         }
         finally {
+            lock.lock();
             try {
-                lock.lock();
                 boolean hardCancelled = hardCancelledDescriptors.remove(activeDescriptor);
                 
                 if (retVal != null) {
@@ -374,8 +374,8 @@ public class AsyncRunLevelContext {
      * @return true if already created, false otherwise
      */
     public boolean containsKey(ActiveDescriptor<?> descriptor) {
+        lock.lock();
         try {
-            lock.lock();
             return backingMap.containsKey(descriptor);
         } finally {
             lock.unlock();
@@ -383,8 +383,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ boolean wouldBlockRightNow(ActiveDescriptor<?> desc) {
+        lock.lock();
         try {
-            lock.lock();
             return creatingDescriptors.containsKey(desc);
         } finally {
             lock.unlock();
@@ -411,8 +411,8 @@ public class AsyncRunLevelContext {
     @SuppressWarnings("unchecked")
     public void destroyOne(ActiveDescriptor<?> descriptor) {
         Object retVal = null;
+        lock.lock();
         try {
-            lock.lock();
             retVal = backingMap.remove(descriptor);
             if (retVal == null) return;
         } finally {
@@ -446,8 +446,8 @@ public class AsyncRunLevelContext {
 
     
     /* package */ int getCurrentLevel() {
+        lock.lock();
         try {
-            lock.lock();
             return currentLevel;
         } finally {
             lock.unlock();
@@ -455,8 +455,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void levelCancelled() {
+        lock.lock();
         try {
-            lock.lock();
             wasCancelled = true;
         } finally {
             lock.unlock();
@@ -464,8 +464,8 @@ public class AsyncRunLevelContext {
     }
 
     /* package */ void setCurrentLevel(int currentLevel) {
+        lock.lock();
         try {
-            lock.lock();
             this.currentLevel = currentLevel;
         } finally {
             lock.unlock();
@@ -473,8 +473,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void setPolicy(RunLevelController.ThreadingPolicy policy) {
+        lock.lock();
         try {
-            lock.lock();
             this.policy = policy;
         } finally {
             lock.unlock();
@@ -482,8 +482,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void setExecutor(Executor executor) {
+        lock.lock();
         try {
-            lock.lock();
             if (executor == null) {
                 this.executor = DEFAULT_EXECUTOR;
             }
@@ -496,8 +496,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ Executor getExecutor() {
+        lock.lock();
         try {
-            lock.lock();
             return executor;
         } finally {
             lock.unlock();
@@ -505,8 +505,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ RunLevelController.ThreadingPolicy getPolicy() {
+        lock.lock();
         try {
-            lock.lock();
             return policy;
         } finally {
             lock.unlock();
@@ -514,8 +514,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ List<ActiveDescriptor<?>> getOrderedListOfServicesAtLevel(int level) {
+        lock.lock();
         try {
-            lock.lock();
             LinkedList<ActiveDescriptor<?>> retVal = new LinkedList<ActiveDescriptor<?>>();
             
             while (!orderedCreationList.isEmpty()) {
@@ -544,8 +544,8 @@ public class AsyncRunLevelContext {
      */
     public RunLevelFuture proceedTo(int level) throws CurrentlyRunningException {
         CurrentTaskFutureWrapper localTask;
+        lock.lock();
         try {
-            lock.lock();
             boolean fullyThreaded = policy.equals(RunLevelController.ThreadingPolicy.FULLY_THREADED);
             
             if (currentTask != null) {
@@ -574,8 +574,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void jobDone() {
+        lock.lock();
         try {
-            lock.lock();
             currentTask = null;
         } finally {
             lock.unlock();
@@ -588,8 +588,8 @@ public class AsyncRunLevelContext {
      * @return The current task, may be null if there is no current task
      */
     public RunLevelFuture getCurrentFuture() {
+        lock.lock();
         try {
-            lock.lock();
             return currentTask;
         } finally {
             lock.unlock();
@@ -597,8 +597,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void setMaximumThreads(int maximum) {
+        lock.lock();
         try {
-            lock.lock();
             if (maximum < 1) {
                 maxThreads = 1;
             }
@@ -611,8 +611,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ int getMaximumThreads() {
+        lock.lock();
         try {
-            lock.lock();
             return maxThreads;
         } finally {
             lock.unlock();
@@ -620,8 +620,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void clearErrors() {
+        lock.lock();
         try {
-            lock.lock();
             levelErrorMap.clear();
             wasCancelled = false;
         } finally {
@@ -630,8 +630,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void setCancelTimeout(long cancelTimeout) {
+        lock.lock();
         try {
-            lock.lock();
             this.cancelTimeout = cancelTimeout;
         } finally {
             lock.unlock();
@@ -639,8 +639,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ long getCancelTimeout() {
+        lock.lock();
         try {
-            lock.lock();
             return cancelTimeout;
         } finally {
             lock.unlock();
@@ -648,8 +648,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ Integer getModeOverride() {
+        lock.lock();
         try {
-            lock.lock();
             return modeOverride;
         } finally {
             lock.unlock();
@@ -657,8 +657,8 @@ public class AsyncRunLevelContext {
     }
     
     /* package */ void setModeOverride(Integer modeOverride) {
+        lock.lock();
         try {
-            lock.lock();
             this.modeOverride = modeOverride;
         } finally {
             lock.unlock();

--- a/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java
+++ b/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java
@@ -117,8 +117,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         UpAllTheWay localUpAllTheWay;
         DownAllTheWay localDownAllTheWay;
         
+        lock.lock();
         try {
-            lock.lock();
             localUpAllTheWay = upAllTheWay;
             localDownAllTheWay = downAllTheWay;
         } finally {
@@ -153,8 +153,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     
     @Override
     public boolean isUp() {
+        lock.lock();
         try {
-            lock.lock();
             if (upAllTheWay != null) return true;
             return false;
         } finally {
@@ -164,8 +164,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     
     @Override
     public boolean isDown() {
+        lock.lock();
         try {
-            lock.lock();
             if (downAllTheWay != null) return true;
             return false;
         } finally {
@@ -209,8 +209,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
      */
     @Override
     public boolean isCancelled() {
+        lock.lock();
         try {
-            lock.lock();
             return cancelled;
         } finally {
             lock.unlock();
@@ -222,8 +222,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
      */
     @Override
     public boolean isDone() {
+        lock.lock();
         try {
-            lock.lock();
             return done;
         } finally {
             lock.unlock();
@@ -232,8 +232,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     
     @Override
     public int getProposedLevel() {
+        lock.lock();
         try {
-            lock.lock();
             return proposedLevel;
         } finally {
             lock.unlock();
@@ -244,8 +244,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     public int changeProposedLevel(int proposedLevel) {
         int oldProposedVal;
         boolean needGo = false;
+        lock.lock();
         try {
-            lock.lock();
             if (done) throw new IllegalStateException("Cannot change the proposed level of a future that is already complete");
             if (!inCallback) throw new IllegalStateException(
                     "changeProposedLevel must only be called from inside a RunLevelListener callback method");
@@ -302,8 +302,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     }
     
     private void setInCallback(boolean inCallback) {
+        lock.lock();
         try {
-            lock.lock();
             this.inCallback = inCallback;
         } finally {
             lock.unlock();
@@ -330,8 +330,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
     public Object get(long timeout, TimeUnit unit) throws InterruptedException,
             ExecutionException, TimeoutException {
         AllTheWay allTheWay = null;
+        lock.lock();
         try {
-            lock.lock();
             if (upAllTheWay != null) {
                 allTheWay = upAllTheWay;
             }
@@ -349,8 +349,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             try {
                 result = allTheWay.waitForResult(timeout, unit);
                 if (result == null) {
+                    lock.lock();
                     try {
-                        lock.lock();
                         if (upAllTheWay != null) {
                             allTheWay = upAllTheWay;
                         }
@@ -368,8 +368,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     throw new TimeoutException();
                 }
                 
+                lock.lock();
                 try {
-                    lock.lock();
                     done = true;
                 } finally {
                     lock.unlock();
@@ -378,8 +378,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 return null;
             }
             catch (MultiException me) {
+                lock.lock();
                 try {
-                    lock.lock();
                     done = true;
                 } finally {
                     lock.unlock();
@@ -522,8 +522,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void cancel() {
+            lock.lock();
             try {
-                lock.lock();
                 cancelled = true;
                 asyncContext.levelCancelled();
                 currentJob.cancel();
@@ -536,8 +536,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         public Boolean waitForResult(long timeout, TimeUnit unit) throws InterruptedException, MultiException {
             long totalWaitTimeMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
             
+            lock.lock();
             try {
-                lock.lock();
                 while (totalWaitTimeMillis > 0L && !done && !repurposed) {
                     long startTime = System.currentTimeMillis();
                     
@@ -560,8 +560,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void setGoingTo(int goingTo, boolean repurposed) {
+            lock.lock();
             try {
-                lock.lock();
                 this.goingTo = goingTo;
                 if (repurposed) {
                     this.repurposed = true;
@@ -573,8 +573,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         
         private void go() {
             if (useThreads) {
+                lock.lock();
                 try {
-                    lock.lock();
                     workingOn++;
                     if (workingOn > goingTo) {
                         if (!repurposed) {
@@ -604,8 +604,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
             workingOn++;
             while (workingOn <= goingTo) {
+                lock.lock();
                 try {
-                    lock.lock();
                     if (done) break;
                     
                     currentJob = new UpOneLevel(workingOn,
@@ -623,9 +623,9 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
                 workingOn++;
             }
-             
+            
+            lock.lock();
             try {
-                lock.lock();
                 if (done) return;
                 
                 if (!repurposed) {
@@ -648,8 +648,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
                 downer.run();
                 
+                lock.lock();
                 try {
-                    lock.lock();
                     done = true;
                     this.exception = accumulatedExceptions;
                     condition.signalAll();;
@@ -663,8 +663,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             }
             
             DownAllTheWay downer = null;
+            lock.lock();
             try {
-                lock.lock();
                 if (cancelled) {
                     downer = new DownAllTheWay(workingOn - 1, null, null);
                 }
@@ -677,8 +677,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 
                 invokeOnCancelled(future, workingOn - 1, listeners);
                 
+                lock.lock();
                 try {
-                    lock.lock();
                     done = true;
                     condition.signalAll();
                         
@@ -735,8 +735,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void cancel() {
+            lock.lock();
             try {
-                lock.lock();
                 cancelled = true;
                 hardCanceller = new CancelTimer(this);
                 timer.schedule(hardCanceller, cancelTimeout);
@@ -746,18 +746,18 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void hardCancel() {
+            asyncContext.lock.lock();
             try {
-                asyncContext.lock.lock();
+                lock.lock();
                 try {
-                    lock.lock();
                     hardCancelled = true;
                 } finally {
                     lock.unlock();
                 }
                 
                 HashSet<ServiceHandle<?>> poisonMe;
+                queueLock.lock();
                 try {
-                    queueLock.lock();
                     poisonMe = new HashSet<ServiceHandle<?>>(outstandingHandles);
                     outstandingHandles.clear();
                 } finally {
@@ -848,8 +848,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void fail(Throwable th, Descriptor descriptor) {
+            lock.lock();
             try {
-                lock.lock();
                 if (hardCancelled) return;
                 
                 ErrorInformation info = invokeOnError(currentTaskFuture, th,
@@ -871,8 +871,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         
         private void jobComplete() {
             boolean complete = false;
+            lock.lock();
             try {
-                lock.lock();
                 if (hardCancelled) return;
                 
                 completedJobs++;
@@ -957,8 +957,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             List<ActiveDescriptor<?>> localQueue;
             ReentrantLock localQueueLock;
             Condition localQueueCondition;
+            lock.lock();
             try {
-                lock.lock();
                 if (cancelled) return; // idempotent
                 cancelled = true;
                 
@@ -970,9 +970,9 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             } finally {
                 lock.unlock();
             }
-                
+            
+            queueLock.lock();
             try {
-                queueLock.lock();
                 if (localQueue.isEmpty()) return;
                 
                 hardCancelDownTimer = new HardCancelDownTimer(this, localQueue, localQueueLock, localQueueCondition);
@@ -983,8 +983,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private void setGoingTo(int goingTo, boolean repurposed) {
+            lock.lock();
             try {
-                lock.lock();
                 this.goingTo = goingTo;
                 if (repurposed) {
                     this.repurposed = true;
@@ -995,8 +995,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         }
         
         private int getGoingTo() {
+            lock.lock();
             try {
-                lock.lock();
                 return goingTo;
             } finally {
                 lock.unlock();
@@ -1008,8 +1008,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             while (workingOn > getGoingTo()) {
                 boolean runOnCancelled;
                 boolean localCancelled;
+                lock.lock();
                 try {
-                    lock.lock();
                     localCancelled = cancelled;
                     runOnCancelled = cancelled && (future != null);
                 } finally {
@@ -1021,8 +1021,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     invokeOnCancelled(future, workingOn, listeners);
                 }
                 
+                lock.lock();
                 try {
-                    lock.lock();
                     if (localCancelled) {
                         asyncContext.jobDone();
                         
@@ -1048,8 +1048,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 List<ActiveDescriptor<?>> localQueue = asyncContext.getOrderedListOfServicesAtLevel(workingOn);
                 ReentrantLock localQueueLock = new ReentrantLock();
                 Condition localQueueCondition = localQueueLock.newCondition();
+                lock.lock();
                 try {
-                    lock.lock();
                     queue = localQueue;
                     queueLock = localQueueLock;
                     queueCondition = localQueueCondition;
@@ -1058,8 +1058,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 }
                 
                 ErrorInformation errorInfo = null;
+                queueLock.lock();
                 try {
-                    queueLock.lock();
                     for (;;) {
                         DownQueueRunner currentRunner = new DownQueueRunner(queueLock, queueCondition, queue, this, locator);
                         executor.execute(currentRunner);
@@ -1103,8 +1103,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     queueLock.unlock();
                 }
                 
+                lock.lock();
                 try {
-                    lock.lock();
                     queue = Collections.emptyList();
                     queueLock = new ReentrantLock();
                     queueCondition = queueLock.newCondition();
@@ -1113,8 +1113,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 }
                 
                 if (errorInfo != null && ErrorInformation.ErrorAction.GO_TO_NEXT_LOWER_LEVEL_AND_STOP.equals(errorInfo.getAction())) {
+                    lock.lock();
                     try {
-                        lock.lock();
                         goingTo = workingOn;
                     } finally {
                         lock.unlock();
@@ -1134,8 +1134,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                 return;
             }
             
+            lock.lock();
             try {
-                lock.lock();
                 if (!repurposed) {
                     asyncContext.jobDone();
                 
@@ -1153,8 +1153,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         public Boolean waitForResult(long timeout, TimeUnit unit) throws InterruptedException, MultiException {
             long totalWaitTimeMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
             
+            lock.lock();
             try {
-                lock.lock();
                 while (totalWaitTimeMillis > 0L && !done && !repurposed) {
                     long startTime = System.currentTimeMillis();
                     
@@ -1192,8 +1192,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
 
         @Override
         public void run() {
+            localQueueLock.lock();
             try {
-                localQueueLock.lock();
                 int currentSize = queue.size();
                 if (currentSize == 0) return;
                 
@@ -1243,8 +1243,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             for (;;) {
                 ServiceHandle<?> job;
                 boolean block;
+                queueLock.lock();
                 try {
-                    queueLock.lock();
                     if (runningHandle != null) parent.jobFinished(runningHandle);
                     
                     if (wouldHaveBlocked != null) {
@@ -1348,8 +1348,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
             boolean completed = true;
             try {
                 boolean ok;
+                parentLock.lock();
                 try {
-                    parentLock.lock();
                     ok = (!parent.cancelled && (parent.accumulatedExceptions == null));
                 } finally {
                     parentLock.unlock();
@@ -1411,8 +1411,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
         public void run() {
             for (;;) {
                 ActiveDescriptor<?> job = null;
+                queueLock.lock();
                 try {
-                    queueLock.lock();
                     if (caput) return;
                     
                     if (queue.isEmpty()) {
@@ -1428,8 +1428,8 @@ public class CurrentTaskFuture implements ChangeableRunLevelFuture {
                     locator.getServiceHandle(job).destroy();
                 }
                 catch (Throwable th) {
+                    queueLock.lock();
                     try {
-                        queueLock.lock();
                         parent.lastError = th;
                         parent.lastErrorDescriptor = job;
                         queueCondition.signal();

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/LevelFiveService.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/LevelFiveService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,9 @@
 
 package org.glassfish.hk2.runlevel.tests.listener;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.annotation.PreDestroy;
 
 import org.glassfish.hk2.runlevel.RunLevel;
@@ -29,17 +32,22 @@ import org.glassfish.hk2.runlevel.RunLevel;
  */
 @RunLevel(5)
 public class LevelFiveService {
-    private boolean preDestroyCalled = false;
-    
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private AtomicBoolean preDestroyCalled = new AtomicBoolean(false);
+
     @SuppressWarnings("unused")
     @PreDestroy
     private void preDestroy() {
-        preDestroyCalled = true;
-        
+        preDestroyCalled.set(true);
+        latch.countDown();
     }
     
     /* package */ boolean isPreDestroyCalled() {
-        return preDestroyCalled;
+        return preDestroyCalled.get();
     }
 
+    /* package */ CountDownLatch latch() {
+        return latch;
+    }
 }

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/LevelFiveService.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/LevelFiveService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,9 +16,6 @@
 
 package org.glassfish.hk2.runlevel.tests.listener;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.annotation.PreDestroy;
 
 import org.glassfish.hk2.runlevel.RunLevel;
@@ -32,22 +29,17 @@ import org.glassfish.hk2.runlevel.RunLevel;
  */
 @RunLevel(5)
 public class LevelFiveService {
-
-    private final CountDownLatch latch = new CountDownLatch(1);
-    private AtomicBoolean preDestroyCalled = new AtomicBoolean(false);
-
+    private boolean preDestroyCalled = false;
+    
     @SuppressWarnings("unused")
     @PreDestroy
     private void preDestroy() {
-        preDestroyCalled.set(true);
-        latch.countDown();
+        preDestroyCalled = true;
+        
     }
     
     /* package */ boolean isPreDestroyCalled() {
-        return preDestroyCalled.get();
+        return preDestroyCalled;
     }
 
-    /* package */ CountDownLatch latch() {
-        return latch;
-    }
 }

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/ListenerErrorTest.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/ListenerErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,6 +15,8 @@
  */
 
 package org.glassfish.hk2.runlevel.tests.listener;
+
+import java.util.concurrent.TimeUnit;
 
 import org.glassfish.hk2.api.Descriptor;
 import org.glassfish.hk2.api.MultiException;
@@ -165,9 +167,10 @@ public class ListenerErrorTest {
     /**
      * Ensures the user can halt the downward level progression if a service
      * failed when going down
+     * @throws InterruptedException 
      */
     @Test
-    public void testHaltLevelRegressionOnError() {
+    public void testHaltLevelRegressionOnError() throws InterruptedException {
         ServiceLocator locator = Utilities.getServiceLocator(LevelFiveDownErrorService.class,
                 LevelFiveService.class,
                 OnProgressLevelChangerListener.class);
@@ -192,16 +195,19 @@ public class ListenerErrorTest {
         OnProgressLevelChangerListener listener = locator.getService(OnProgressLevelChangerListener.class);
         
         Assert.assertEquals(4, listener.getLatestOnProgress());
-        
+
+        levelFiveService.latch().await(100, TimeUnit.MILLISECONDS);
+
         Assert.assertTrue(levelFiveService.isPreDestroyCalled());
     }
     
     /**
      * Ensures the user can halt the downward level progression if a service
      * failed when going down
+     * @throws InterruptedException 
      */
     @Test
-    public void testHaltLevelRegressionOnErrorNoThreads() {
+    public void testHaltLevelRegressionOnErrorNoThreads() throws InterruptedException {
         ServiceLocator locator = Utilities.getServiceLocator(LevelFiveDownErrorService.class,
                 LevelFiveService.class,
                 OnProgressLevelChangerListener.class);
@@ -228,6 +234,8 @@ public class ListenerErrorTest {
         
         Assert.assertEquals(4, listener.getLatestOnProgress());
         
+        levelFiveService.latch().await(100, TimeUnit.MILLISECONDS);
+
         Assert.assertTrue(levelFiveService.isPreDestroyCalled());
     }
     

--- a/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/ListenerErrorTest.java
+++ b/hk2-runlevel/src/test/java/org/glassfish/hk2/runlevel/tests/listener/ListenerErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,8 +15,6 @@
  */
 
 package org.glassfish.hk2.runlevel.tests.listener;
-
-import java.util.concurrent.TimeUnit;
 
 import org.glassfish.hk2.api.Descriptor;
 import org.glassfish.hk2.api.MultiException;
@@ -167,10 +165,9 @@ public class ListenerErrorTest {
     /**
      * Ensures the user can halt the downward level progression if a service
      * failed when going down
-     * @throws InterruptedException 
      */
     @Test
-    public void testHaltLevelRegressionOnError() throws InterruptedException {
+    public void testHaltLevelRegressionOnError() {
         ServiceLocator locator = Utilities.getServiceLocator(LevelFiveDownErrorService.class,
                 LevelFiveService.class,
                 OnProgressLevelChangerListener.class);
@@ -195,19 +192,16 @@ public class ListenerErrorTest {
         OnProgressLevelChangerListener listener = locator.getService(OnProgressLevelChangerListener.class);
         
         Assert.assertEquals(4, listener.getLatestOnProgress());
-
-        levelFiveService.latch().await(100, TimeUnit.MILLISECONDS);
-
+        
         Assert.assertTrue(levelFiveService.isPreDestroyCalled());
     }
     
     /**
      * Ensures the user can halt the downward level progression if a service
      * failed when going down
-     * @throws InterruptedException 
      */
     @Test
-    public void testHaltLevelRegressionOnErrorNoThreads() throws InterruptedException {
+    public void testHaltLevelRegressionOnErrorNoThreads() {
         ServiceLocator locator = Utilities.getServiceLocator(LevelFiveDownErrorService.class,
                 LevelFiveService.class,
                 OnProgressLevelChangerListener.class);
@@ -234,8 +228,6 @@ public class ListenerErrorTest {
         
         Assert.assertEquals(4, listener.getLatestOnProgress());
         
-        levelFiveService.latch().await(100, TimeUnit.MILLISECONDS);
-
         Assert.assertTrue(levelFiveService.isPreDestroyCalled());
     }
     

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/LRUHybridCache.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/LRUHybridCache.java
@@ -259,8 +259,8 @@ public class LRUHybridCache<K,V> implements Computable<K, HybridCacheEntry<V>> {
                 LRUHybridCache<K,V>.OriginThreadAwareFuture ft =
                         new LRUHybridCache.OriginThreadAwareFuture(this, key);
 
+                prunningLock.lock();
                 try {
-                    prunningLock.lock();
                     if (cache.size() + 1 > maxCacheSize) {
                         removeLRUItem();
                     }

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/LRUHybridCache.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/LRUHybridCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Hybrid cache that allows explicit removals of included entries as well
@@ -160,7 +161,7 @@ public class LRUHybridCache<K,V> implements Computable<K, HybridCacheEntry<V>> {
     private final ConcurrentHashMap<K, LRUHybridCache<K,V>.OriginThreadAwareFuture> cache = new ConcurrentHashMap<K, LRUHybridCache<K,V>.OriginThreadAwareFuture>();
     private final Computable<K, HybridCacheEntry<V>> computable;
 
-    private final Object prunningLock = new Object();
+    private final ReentrantLock prunningLock = new ReentrantLock();
     private final int maxCacheSize;
 
     /**
@@ -258,11 +259,14 @@ public class LRUHybridCache<K,V> implements Computable<K, HybridCacheEntry<V>> {
                 LRUHybridCache<K,V>.OriginThreadAwareFuture ft =
                         new LRUHybridCache.OriginThreadAwareFuture(this, key);
 
-                synchronized (prunningLock) {
+                try {
+                    prunningLock.lock();
                     if (cache.size() + 1 > maxCacheSize) {
                         removeLRUItem();
                     }
                     f = cache.putIfAbsent(key, ft);
+                } finally {
+                    prunningLock.unlock();
                 }
                 if (f == null) {
                     f = ft;

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/LRUCacheCheapRead.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/LRUCacheCheapRead.java
@@ -65,8 +65,8 @@ public class LRUCacheCheapRead<K,V> extends LRUCache<K,V> {
     @Override
     public CacheEntry put(K key, V value) {
         CacheEntryImpl<K, V> entry = new CacheEntryImpl<K, V>(key, value, this);
+        prunningLock.lock();
         try {
-            prunningLock.lock();
             if (cache.size() + 1 > maxCacheSize) {
                 removeLRUItem();
             }

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/WeakCARCacheImpl.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/cache/internal/WeakCARCacheImpl.java
@@ -94,8 +94,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
             return value;
         }
         
+        lock.lock();
         try {
-            lock.lock();
             value = getValueFromT(key);
             if (value != null) {
                 hits.getAndIncrement();
@@ -217,8 +217,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      */
     @Override
     public int getKeySize() {
+        lock.lock();
         try {
-            lock.lock();
             return t1.size() + t2.size() + b1.size() + b2.size();
         } finally {
             lock.unlock();
@@ -230,8 +230,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      */
     @Override
     public int getValueSize() {
+        lock.lock();
         try {
-            lock.lock();
             return t1.size() + t2.size();
         } finally {
             lock.unlock();
@@ -243,8 +243,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      */
     @Override
     public void clear() {
+        lock.lock();
         try {
-            lock.lock();
             t1.clear();
             t2.clear();
             b1.clear();
@@ -280,8 +280,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      */
     @Override
     public boolean remove(K key) {
+        lock.lock();
         try {
-            lock.lock();
             if (t1.remove(key) == null) {
                 if (t2.remove(key) == null) {
                     if (!b1.remove(key)) {
@@ -305,8 +305,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      */
     @Override
     public void releaseMatching(CacheKeyFilter<K> filter) {
+        lock.lock();
         try {
-            lock.lock();
             if (filter == null) return;
             
             b2.releaseMatching(filter);
@@ -323,8 +323,8 @@ public class WeakCARCacheImpl<K,V> implements WeakCARCache<K, V> {
      */
     @Override
     public void clearStaleReferences() {
+        lock.lock();
         try {
-            lock.lock();
             t1.clearStaleReferences();
             t2.clearStaleReferences();
             b1.clearStaleReferences();

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/ValidatorUtilities.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/ValidatorUtilities.java
@@ -79,8 +79,8 @@ public class ValidatorUtilities {
      * @return A javax bean validator for validating constraints
      */
     public static Validator getValidator() {
+        slock.lock();
         try {
-            slock.lock();
             if (validator == null) {
                 validator = AccessController.doPrivileged(new PrivilegedAction<Validator>() {
 

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/ValidatorUtilities.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/ValidatorUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.hk2.utilities.general;
 import java.lang.annotation.ElementType;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.validation.Path;
 import javax.validation.TraversableResolver;
@@ -36,6 +37,7 @@ import org.hibernate.validator.HibernateValidator;
  *
  */
 public class ValidatorUtilities {
+    private static final ReentrantLock slock = new ReentrantLock();
     private static final TraversableResolver TRAVERSABLE_RESOLVER = new TraversableResolver() {
         public boolean isReachable(Object traversableObject,
                 Path.Node traversableProperty, Class<?> rootBeanType,
@@ -76,23 +78,28 @@ public class ValidatorUtilities {
      * 
      * @return A javax bean validator for validating constraints
      */
-    public synchronized static Validator getValidator() {
-        if (validator == null) {
-            validator = AccessController.doPrivileged(new PrivilegedAction<Validator>() {
+    public static Validator getValidator() {
+        try {
+            slock.lock();
+            if (validator == null) {
+                validator = AccessController.doPrivileged(new PrivilegedAction<Validator>() {
 
-                @Override
-                public Validator run() {
-                    return initializeValidator();
-                }
-                
-            });
+                    @Override
+                    public Validator run() {
+                        return initializeValidator();
+                    }
+                    
+                });
+            }
+            
+            if (validator == null) {
+                throw new IllegalStateException("Could not find a javax.validator");
+            }
+            
+            return validator;
+        } finally {
+            slock.unlock();
         }
-        
-        if (validator == null) {
-            throw new IllegalStateException("Could not find a javax.validator");
-        }
-        
-        return validator;
     }
 
 }

--- a/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/internal/WeakHashClockImpl.java
+++ b/hk2-utils/src/main/java/org/glassfish/hk2/utilities/general/internal/WeakHashClockImpl.java
@@ -119,8 +119,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     public void put(final K key, final V value) {
         if (key == null || value == null) throw new IllegalArgumentException("key " + key + " or value " + value + " is null");
         
+        lock.lock();
         try {
-            lock.lock();
             if (isWeak) {
                 removeStale();
             }
@@ -147,8 +147,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
         
         DoubleNode<K,V> node;
         if (isWeak) {
+            lock.lock();
             try {
-                lock.lock();
                 removeStale();
         
                 node = byKey.get(key);
@@ -172,8 +172,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     public V remove(K key) {
         if (key == null) return null;
         
+        lock.lock();
         try {
-            lock.lock();
             DoubleNode<K,V> node;
             if (isWeak) {
                 removeStale();
@@ -199,8 +199,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      */
     @Override
     public void releaseMatching(CacheKeyFilter<K> filter) {
+        lock.lock();
         try {
-            lock.lock();
             if (filter == null) return;
             
             if (isWeak) {
@@ -232,8 +232,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     @Override
     public int size() {
         if (isWeak) {
+            lock.lock();
             try {
-                lock.lock();
                 removeStale();
         
                 return byKey.size();
@@ -277,8 +277,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      */
     @Override
     public Entry<K, V> next() {
+        lock.lock();
         try {
-            lock.lock();
             DoubleNode<K,V> hardenedNode = moveDotNoWeak();
             if (hardenedNode == null) return null;
             try {
@@ -319,8 +319,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      */
     @Override
     public void clear() {
+        lock.lock();
         try {
-            lock.lock();
             if (isWeak) {
                 byKey.clear();
             }
@@ -339,8 +339,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
      */
     @Override
     public void clearStaleReferences() {
+        lock.lock();
         try {
-            lock.lock();
             removeStale();
         } finally {
             lock.unlock();
@@ -377,8 +377,8 @@ public class WeakHashClockImpl<K,V> implements WeakHashClock<K,V> {
     
     @Override
     public String toString() {
+        lock.lock();
         try {
-            lock.lock();
             StringBuffer sb = new StringBuffer("WeakHashClockImpl({");
             
             boolean first = true;

--- a/spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java
+++ b/spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,8 @@
 
 package org.jvnet.hk2.spring.bridge.api;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceHandle;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -29,14 +31,20 @@ import org.springframework.beans.factory.config.Scope;
  *
  */
 public class SpringScopeImpl implements Scope {
+    private final ReentrantLock lock = new ReentrantLock();
     private ServiceLocator locator;
     
     /**
      * Sets the service locator to use with this scope
      * @param locator The (non-null) locator to use for this scope
      */
-    public synchronized void setServiceLocator(ServiceLocator locator) {
-        this.locator = locator;
+    public void setServiceLocator(ServiceLocator locator) {
+        try {
+            lock.lock();
+            this.locator = locator;
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -46,8 +54,13 @@ public class SpringScopeImpl implements Scope {
      * @param name The name to be used.  If null an anonymous service
      * locator will be used
      */
-    public synchronized void setServiceLocatorName(String name) {
-        locator = ServiceLocatorFactory.getInstance().create(name);
+    public void setServiceLocatorName(String name) {
+        try {
+            lock.lock();
+            locator = ServiceLocatorFactory.getInstance().create(name);
+        } finally {
+            lock.unlock();
+        }
     }
     
     /**
@@ -56,18 +69,28 @@ public class SpringScopeImpl implements Scope {
      * 
      * @return The {@link ServiceLocator} to be used with this scope
      */
-    public synchronized ServiceLocator getServiceLocator() {
-        return locator;
+    public ServiceLocator getServiceLocator() {
+        try {
+            lock.lock();
+            return locator;
+        } finally {
+            lock.unlock();
+        }
     }
     
-    private synchronized ServiceHandle<?> getServiceFromName(String id) {
-        if (locator == null) throw new IllegalStateException(
-                "ServiceLocator must be set");
-        
-        ActiveDescriptor<?> best = locator.getBestDescriptor(BuilderHelper.createTokenizedFilter(id));
-        if (best == null) return null;
-        
-        return locator.getServiceHandle(best);
+    private ServiceHandle<?> getServiceFromName(String id) {
+        try {
+            lock.lock();
+            if (locator == null) throw new IllegalStateException(
+                    "ServiceLocator must be set");
+            
+            ActiveDescriptor<?> best = locator.getBestDescriptor(BuilderHelper.createTokenizedFilter(id));
+            if (best == null) return null;
+            
+            return locator.getServiceHandle(best);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /* (non-Javadoc)

--- a/spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java
+++ b/spring-bridge/src/main/java/org/jvnet/hk2/spring/bridge/api/SpringScopeImpl.java
@@ -39,8 +39,8 @@ public class SpringScopeImpl implements Scope {
      * @param locator The (non-null) locator to use for this scope
      */
     public void setServiceLocator(ServiceLocator locator) {
+        lock.lock();
         try {
-            lock.lock();
             this.locator = locator;
         } finally {
             lock.unlock();
@@ -55,8 +55,8 @@ public class SpringScopeImpl implements Scope {
      * locator will be used
      */
     public void setServiceLocatorName(String name) {
+        lock.lock();
         try {
-            lock.lock();
             locator = ServiceLocatorFactory.getInstance().create(name);
         } finally {
             lock.unlock();
@@ -70,8 +70,8 @@ public class SpringScopeImpl implements Scope {
      * @return The {@link ServiceLocator} to be used with this scope
      */
     public ServiceLocator getServiceLocator() {
+        lock.lock();
         try {
-            lock.lock();
             return locator;
         } finally {
             lock.unlock();
@@ -79,8 +79,8 @@ public class SpringScopeImpl implements Scope {
     }
     
     private ServiceHandle<?> getServiceFromName(String id) {
+        lock.lock();
         try {
-            lock.lock();
             if (locator == null) throw new IllegalStateException(
                     "ServiceLocator must be set");
             


### PR DESCRIPTION
Synchronized blocks, will block platform threads using virtual threads with JDK 21+.

To avoid to block platform threads, we need to replace every synchronized by ReentrantLock.

This PR does not contain any other optimization.

Special attention reviewing:
`glassfish-hk2/hk2-runlevel/src/main/java/org/glassfish/hk2/runlevel/internal/CurrentTaskFuture.java`

I am not applying this change in tests and examples.