### PR TITLE
Ugrade ASM to support higher JDK versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 .classpath
+.factorypath
 .project
 .settings/
 *.iml

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractAnnotationVisitorImpl.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractAnnotationVisitorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,7 @@ public abstract class AbstractAnnotationVisitorImpl extends AnnotationVisitor {
      * Gives the version implemented to the superclass
      */
     public AbstractAnnotationVisitorImpl() {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
     }
     
     /* (non-Javadoc)

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractClassVisitorImpl.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractClassVisitorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,7 @@ public abstract class AbstractClassVisitorImpl extends ClassVisitor {
      * The constructor that gives the version we are implementing to the superclass
      */
     public AbstractClassVisitorImpl() {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
     }
 
     /* (non-Javadoc)

--- a/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractMethodVisitorImpl.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/main/java/org/jvnet/hk2/generator/internal/AbstractMethodVisitorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@ public abstract class AbstractMethodVisitorImpl extends MethodVisitor {
      * The constructor that gives the implemented version to the superclass
      */
     public AbstractMethodVisitorImpl() {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
     }
 
     /* (non-Javadoc)

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -152,7 +152,7 @@
         <jtype.version>0.1.0</jtype.version>
         <javassist.version>3.27.0-GA</javassist.version>
         <junit.version>4.12</junit.version>
-        <asm.version>7.1</asm.version>
+        <asm.version>9.6</asm.version>
         <woodstox.version>4.1.2</woodstox.version>
         <stax-api.version>1.0-2</stax-api.version>
         <aopalliance.version>1.0</aopalliance.version>


### PR DESCRIPTION
Upgrading to ASM 9.6, that is supported from JDK 1.5:
```

$ javap -verbose /home/jbescos/Downloads/asm-9.6/org/objectweb/asm/Opcodes.class | grep major
  major version: 49
```

Some context: WLS 14.1.2 uses JDK 17