### PR TITLE
Update OSGi Enterprise to 7.0.0

### DIFF
--- a/class-model/pom.xml
+++ b/class-model/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency><!-- Needed to have a bundle activator to set up a different serialization policy-->
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
+            <artifactId>osgi.enterprise</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -325,8 +325,8 @@
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.enterprise</artifactId>
-                <version>5.0.0</version>
+                <artifactId>osgi.enterprise</artifactId>
+                <version>7.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Updates `osgi.enterprise` to 7.0.0.

Related PR to master branch: https://github.com/eclipse-ee4j/glassfish-hk2/pull/976