### PR TITLE
Drop `logback` dependencies

### DIFF
--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to Eclipse Foundation. All rights reserved.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2020 Payara Services Ltd.
 
@@ -179,14 +180,6 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2023 Contributors to Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to Eclipse Foundation. All rights reserved.
     Copyright (c) 2020, 2021 Payara Services Ltd.
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
 
@@ -374,16 +374,6 @@
                 <groupId>org.ops4j.pax.url</groupId>
                 <artifactId>pax-url-aether</artifactId>
                 <version>2.6.14</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>1.4.14</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>1.4.14</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
These managed dependencies seem to be used only in
https://github.com/eclipse-ee4j/glassfish-hk2/blob/8ed1807b41a7e46e8aa251e6c2913ef689bec63a/osgi/adapter-tests/osgi-adapter-test/pom.xml#L183-L190
But the `osgi-adapter-test` module was removed from the build anyway https://github.com/eclipse-ee4j/glassfish-hk2/blob/8ed1807b41a7e46e8aa251e6c2913ef689bec63a/osgi/adapter-tests/pom.xml#L38
- via #501 / 2b815f6a44a10e0fe63a005d4a4760d9228c75b5

Even if `osgi-adapter-test` was included - I could not see `logback` to transit in other version from anything there.


IF re-including `osgi-adapter-test` in the build would require `logback` - we could have it back again then.

-----
- Closes #992
- Closes #993