### PR TITLE
Add OSGi Exports to HK2-Extras

### DIFF
--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -84,6 +84,17 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            org.glassfish.hk2.extras; \
+                            org.glassfish.hk2.extras.events; \
+                            org.glassfish.hk2.extras.interception; \
+                            org.glassfish.hk2.extras.operation; \
+                            org.glassfish.hk2.extras.provides; version=${project.osgi.version}
+                        </Export-Package>
+                    </instructions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>


### PR DESCRIPTION
Adds exports to the HK2-Extras module.
The subtle change to the bundle plugin config applied in https://github.com/eclipse-ee4j/glassfish-hk2/pull/899 which fixed the global config by making it no longer ignore the instruction to not export anything means that without an override this module doesn't export anything. I'd argue it should be exporting stuff, as things can depend on it.

I've limited the exports to anything not in an "internal" package.