### PR TITLE
Keep only the artifacts of the last 2 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   agent any
   options {
     // keep at most 50 builds
-    buildDiscarder(logRotator(numToKeepStr: '50'))
+    buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '2'))
     // abort pipeline if previous stage is unstable
     skipStagesAfterUnstable()
     // show timestamps in logs


### PR DESCRIPTION
To save disk space, the number of builds to keep with artifacts should be limited to 2.

This change should be applied to all branches and PRs.