### PR TITLE
Increase global timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     // show timestamps in logs
     timestamps()
     // global timeout
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 120, unit: 'MINUTES')
   }
   stages {
     stage('build') {


### PR DESCRIPTION
This one took
![image](https://github.com/user-attachments/assets/f0a1f279-6ff8-44d6-8a27-40eb482ca48e)


I propose the increase, as IMO it's better to have green Jenkins build rather than timout-related. I'd prefer to see failures for the code-related reasons.