### PR TITLE
Hamcrest update, pom cleanup

### DIFF
--- a/class-model/pom.xml
+++ b/class-model/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>class-model</artifactId>
 
     <name>Class Model for Hk2</name>
@@ -62,6 +61,14 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency><!-- Needed to have a bundle activator to set up a different serialization policy-->
             <groupId>org.osgi</groupId>

--- a/examples/caching/runner/pom.xml
+++ b/examples/caching/runner/pom.xml
@@ -52,6 +52,15 @@
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/configuration/webserver/pom.xml
+++ b/examples/configuration/webserver/pom.xml
@@ -66,6 +66,15 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/configuration/xml/pom.xml
+++ b/examples/configuration/xml/pom.xml
@@ -76,6 +76,15 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/custom-resolver/pom.xml
+++ b/examples/custom-resolver/pom.xml
@@ -67,6 +67,14 @@
             <artifactId>hk2-locator</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/events/threaded/pom.xml
+++ b/examples/events/threaded/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/operations/pom.xml
+++ b/examples/operations/pom.xml
@@ -72,6 +72,15 @@
             <artifactId>hk2-extras</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/security-lockdown/runner/pom.xml
+++ b/examples/security-lockdown/runner/pom.xml
@@ -63,6 +63,15 @@
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/guice-bridge/pom.xml
+++ b/guice-bridge/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>guice-bridge</artifactId>
 
     <name>HK2 Guice Bridge</name>
@@ -52,6 +51,14 @@
             <artifactId>hk2-junitrunner</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-api/pom.xml
+++ b/hk2-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Contributors to Eclipse Foundation.
+    Copyright (c) 2025, 2026 Contributors to Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2019, 2020 Payara Services Ltd.
 
@@ -28,7 +28,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-api</artifactId>
 
     <name>HK2 API module</name>
@@ -53,6 +52,18 @@
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>aopalliance-repackaged</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-configuration/hk2-integration/pom.xml
+++ b/hk2-configuration/hk2-integration/pom.xml
@@ -58,6 +58,15 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/manager/pom.xml
+++ b/hk2-configuration/manager/pom.xml
@@ -49,6 +49,15 @@
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-json/pom.xml
@@ -66,6 +66,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/hk2-pbuf/pom.xml
@@ -66,6 +66,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/integration-test/pom.xml
@@ -58,6 +58,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/hk2-xml/main/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/main/pom.xml
@@ -94,6 +94,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/hk2-xml/schema/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/schema/pom.xml
@@ -77,6 +77,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/hk2-xml/test1/pom.xml
+++ b/hk2-configuration/persistence/hk2-xml/test1/pom.xml
@@ -53,6 +53,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-configuration/persistence/property-file/pom.xml
+++ b/hk2-configuration/persistence/property-file/pom.xml
@@ -47,11 +47,20 @@
             <artifactId>hk2-utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-junitrunner</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-core/pom.xml
+++ b/hk2-core/pom.xml
@@ -46,6 +46,14 @@
             <artifactId>hk2-utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-extras/pom.xml
+++ b/hk2-extras/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-extras</artifactId>
 
     <name>HK2 extras module</name>
@@ -72,6 +71,15 @@
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>aopalliance-repackaged</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-locator/pom.xml
+++ b/hk2-locator/pom.xml
@@ -61,6 +61,14 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-metadata-generator/test1/pom.xml
+++ b/hk2-metadata-generator/test1/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-metadata-generator-test1</artifactId>
 
     <name>HK2 Metadata Generator Test One</name>
@@ -61,6 +60,14 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-runlevel/pom.xml
+++ b/hk2-runlevel/pom.xml
@@ -53,6 +53,14 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-testing/ant/pom.xml
+++ b/hk2-testing/ant/pom.xml
@@ -32,7 +32,7 @@
     <name>HK2 Ant Inhabitant Generator Test</name>
     <description>Tests Ant running HK2 Inhabitant Generator</description>
 
-    <properties>        
+    <properties>
         <manifest.location></manifest.location> <!-- to make nullifiy the property -->
     </properties>
 
@@ -41,6 +41,14 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-testing/collections/pom.xml
+++ b/hk2-testing/collections/pom.xml
@@ -35,6 +35,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-testing/di-tck/pom.xml
+++ b/hk2-testing/di-tck/pom.xml
@@ -66,6 +66,7 @@
                     </artifactItems>
                     <overWriteReleases>false</overWriteReleases>
                     <overWriteSnapshots>true</overWriteSnapshots>
+                    <excludes>module-info.class</excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -105,6 +106,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>

--- a/hk2-testing/di-tck/pom.xml
+++ b/hk2-testing/di-tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
     Copyright (c) 2021 Payara Services Ltd. and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>unpack</id>
@@ -53,7 +52,7 @@
                         <artifactItem>
                             <groupId>jakarta.inject</groupId>
                             <artifactId>jakarta.inject-api</artifactId>
-                            <version>2.0.0</version>
+                            <version>2.0.1</version>
                             <overWrite>false</overWrite>
                             <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                         </artifactItem>
@@ -72,7 +71,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
                 <configuration>
                     <includes>
                         <include>${runSuite}</include>

--- a/hk2-testing/hk2-junitrunner/pom.xml
+++ b/hk2-testing/hk2-junitrunner/pom.xml
@@ -53,11 +53,6 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>
@@ -76,6 +71,16 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-testing/hk2-locator-extras/pom.xml
+++ b/hk2-testing/hk2-locator-extras/pom.xml
@@ -72,6 +72,15 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-testing/hk2-locator-no-proxies/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies/pom.xml
@@ -64,6 +64,14 @@
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-testing/hk2-locator-no-proxies2/pom.xml
+++ b/hk2-testing/hk2-locator-no-proxies2/pom.xml
@@ -54,6 +54,15 @@
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hk2-testing/interceptor-events/pom.xml
+++ b/hk2-testing/interceptor-events/pom.xml
@@ -32,7 +32,7 @@
     <name>Interceptor/Eventing Test Suite</name>
     <description>Tests AOP interceptions along with events</description>
 
-    <properties>        
+    <properties>
         <manifest.location></manifest.location> <!-- to make nullifiy the property -->
     </properties>
 
@@ -61,6 +61,14 @@
             <artifactId>hk2-junitrunner</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/hk2-testing/jersey/jersey-guice/form-param/pom.xml
+++ b/hk2-testing/jersey/jersey-guice/form-param/pom.xml
@@ -33,7 +33,7 @@
     <name>Jersey Guice FormParam Test</name>
     <description>Ensures FormParam comes from HK2</description>
 
-    <properties>        
+    <properties>
         <manifest.location></manifest.location> <!-- to make nullifiy the property -->
     </properties>
 
@@ -62,10 +62,6 @@
             <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet</artifactId>
         </dependency>
@@ -92,7 +88,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/hk2-testing/pom.xml
+++ b/hk2-testing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2021 Payara Services Ltd.
 
@@ -44,5 +44,6 @@
         <module>hk2-mockito</module>
         <module>collections</module>
         <module>jersey</module>
+        <module>di-tck</module>
     </modules>
 </project>

--- a/hk2-utils/pom.xml
+++ b/hk2-utils/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-utils</artifactId>
 
     <name>HK2 Implementation Utilities</name>
@@ -80,6 +79,14 @@
            <version>${glassfish.jakarta.el.version}</version>
            <scope>test</scope>
        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -81,6 +81,18 @@
             <artifactId>ant</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/maven-plugins/hk2-inhabitant-generator/pom.xml
+++ b/maven-plugins/hk2-inhabitant-generator/pom.xml
@@ -148,7 +148,6 @@
                              <excludes>
                                  <exclude>**/negative/*</exclude>
                              </excludes>
-                             <finalName>gendir</finalName>
                              <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                          </configuration>
                      </execution>

--- a/maven-plugins/hk2-inhabitant-generator/src/test/java/org/jvnet/hk2/generator/tests/InhabitantsGeneratorTest.java
+++ b/maven-plugins/hk2-inhabitant-generator/src/test/java/org/jvnet/hk2/generator/tests/InhabitantsGeneratorTest.java
@@ -62,13 +62,13 @@ import org.jvnet.hk2.generator.InFlightGenerator;
 
 /**
  * Tests for the inhabitant generator
- * 
+ *
  * @author jwells
  */
 public class InhabitantsGeneratorTest {
     private final static String CLASS_PATH_PROP = "java.class.path";
     private final static String CLASSPATH = System.getProperty(CLASS_PATH_PROP);
-    
+
     private final static String FILE_ARGUMENT = "--file";
     private final static String OUTJAR_FILE_ARGUMENT = "--outjar";
     private final static String VERBOSE_ARGUMENT = "--verbose";
@@ -76,19 +76,19 @@ public class InhabitantsGeneratorTest {
     private final static String LOCATOR_ARGUMENT = "--locator";
     private final static String CLASS_DIRECTORY = "gendir";
     private final static String NEGATIVE_CLASS_DIRECTORY = "negative";
-    private final static String JAR_FILE = "gendir-tests.jar";
+    private final static String JAR_FILE = "hk2-inhabitant-generator-tests.jar";
     private final static File OUTJAR_FILE = new File("outgendir.jar");
     private final static String COPIED_INPUT_JAR_NAME = "gendirCopy.jar";
-    
+
     private final static String META_INF_NAME = "META-INF";
     private final static String INHABITANTS = "hk2-locator";
     private final static String DEFAULT = "default";
     private final static String OTHER = "other";
-    
+
     private final static String ZIP_FILE_INHABITANT_NAME = "META-INF/hk2-locator/default";
-    
+
     private final static String MAVEN_CLASSES_DIR = "test-classes";
-    
+
     public final static String GENERATE_METHOD_CREATE_IMPL = "com.acme.service.GenerateMethodImpl";
     public final static String GENERATE_METHOD_CREATE_CONTRACT = "com.acme.api.GenerateMethod";
     public final static String GENERATE_METHOD_CREATE_NAME1 = "name1";
@@ -96,11 +96,11 @@ public class InhabitantsGeneratorTest {
     public final static String GENERATE_METHOD_CREATE_NAME3 = "name3";
     public final static String GENERATE_METHOD_CREATE_NAME4 = "name4";
     public final static String GENERATE_METHOD_CREATE_NAME5 = "name5";
-    
+
     public final static String GENERATE_METHOD_DELETE_IMPL = "com.acme.service.DeleteImpl";
     public final static String GENERATE_METHOD_DELETE_CONTRACT = "com.acme.api.GenerateMethod";
     public final static String GENERATE_METHOD_DELETE_SCOPE = "jakarta.inject.Singleton";
-    
+
     // metadata constants
     public final static String KEY1 = "key1";
     public final static String VALUE1 = "value1";
@@ -118,23 +118,23 @@ public class InhabitantsGeneratorTest {
     public final static long VALUE6_1 = 6001L;
     public final static long VALUE6_2 = 6002L;
     public final static long VALUE6_3 = 6003L;
-    
+
     /** The name for non-defaulted things */
     public final static String NON_DEFAULT_NAME = "non-default-name";
-    
+
     /** The rank to use when testing for rank */
     public final static int RANK = 13;
-    
+
     /** The rank to use when testing for rank on factory method */
     public final static int FACTORY_METHOD_RANK = -1;
-    
+
     /** A custom analyzer for a descriptor */
     public final static String CUSTOM_ANALYZER = "CustomAnalyzer";
-    
+
     private final static Map<DescriptorImpl, Integer> EXPECTED_DESCRIPTORS = new HashMap<DescriptorImpl, Integer>();
-    
+
     static {
-        
+
         {
             // This is a descriptor with a defaulted Name and a qualifier and metadata
             DescriptorImpl di = new DescriptorImpl();
@@ -145,10 +145,10 @@ public class InhabitantsGeneratorTest {
             di.addQualifier(Blue.class.getName());
             di.addMetadata(KEY1, VALUE1);
             di.addMetadata(KEY2, VALUE2);
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // This is a descriptor with a non-defaulted Name from @Named
             DescriptorImpl di = new DescriptorImpl();
@@ -157,10 +157,10 @@ public class InhabitantsGeneratorTest {
             di.setName(NON_DEFAULT_NAME);
             di.addQualifier(Named.class.getName());
             di.setScope(Singleton.class.getName());
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // This is a descriptor with a non-defaulted Name from @Service
             DescriptorImpl di = new DescriptorImpl();
@@ -168,10 +168,10 @@ public class InhabitantsGeneratorTest {
             di.addAdvertisedContract("org.jvnet.hk2.generator.tests.ServiceWithName");
             di.setName(NON_DEFAULT_NAME);
             di.setScope(Singleton.class.getName());
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // ComplexFactory as a service
             DescriptorImpl di = new DescriptorImpl();
@@ -181,10 +181,10 @@ public class InhabitantsGeneratorTest {
             di.setName("ComplexFactory");
             di.setScope(Singleton.class.getName());
             di.addQualifier(Named.class.getName());
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // ComplexFactory as a factory
             DescriptorImpl di = new DescriptorImpl();
@@ -199,10 +199,10 @@ public class InhabitantsGeneratorTest {
             di.setDescriptorType(DescriptorType.PROVIDE_METHOD);
             di.addQualifier(Blue.class.getName());
             di.addQualifier(Named.class.getName());
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // Another complex hierarchy
             DescriptorImpl di = new DescriptorImpl();
@@ -212,20 +212,20 @@ public class InhabitantsGeneratorTest {
             di.addAdvertisedContract(ComplexF.class.getName());
             di.addAdvertisedContract(ComplexA.class.getName());
             di.setScope(Singleton.class.getName());
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // This is a descriptor with a non-defaulted Name from @Service
             DescriptorImpl di = new DescriptorImpl();
             di.setImplementation("org.jvnet.hk2.generator.tests.ContractsProvidedService");
             di.addAdvertisedContract("org.jvnet.hk2.generator.tests.SimpleInterface");
             di.setScope(Singleton.class.getName());
-        
+
             EXPECTED_DESCRIPTORS.put(di, 0);
         }
-        
+
         {
             // This is a service with a rank
             DescriptorImpl di = new DescriptorImpl();
@@ -233,10 +233,10 @@ public class InhabitantsGeneratorTest {
             di.addAdvertisedContract(ServiceWithRank.class.getName());
             di.setScope(Singleton.class.getName());
             di.setRanking(RANK);
-        
+
             EXPECTED_DESCRIPTORS.put(di, RANK);
         }
-        
+
         {
             // This is the Factory that should be generated
             DescriptorImpl envFactory = new DescriptorImpl();
@@ -245,10 +245,10 @@ public class InhabitantsGeneratorTest {
             envFactory.addAdvertisedContract(Factory.class.getName());
             envFactory.setScope(Singleton.class.getName());
             envFactory.setRanking(RANK);
-        
+
             EXPECTED_DESCRIPTORS.put(envFactory, RANK);
         }
-        
+
         {
             // This is a factory with a rank
             DescriptorImpl envItself = new DescriptorImpl();
@@ -256,10 +256,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(SimpleInterface.class.getName());
             envItself.setRanking(FACTORY_METHOD_RANK);
             envItself.setDescriptorType(DescriptorType.PROVIDE_METHOD);
-        
+
             EXPECTED_DESCRIPTORS.put(envItself, FACTORY_METHOD_RANK);
         }
-        
+
         {
             // This is a service with automatic metadata
             DescriptorImpl envItself = new DescriptorImpl();
@@ -277,10 +277,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(KEY6, Long.toString(VALUE6_1));
             envItself.addMetadata(KEY6, Long.toString(VALUE6_2));
             envItself.addMetadata(KEY6, Long.toString(VALUE6_3));
-        
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         // All the following descriptors were generated from the GenerateServiceFromMethod
         // annotations
         {
@@ -294,10 +294,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_ACTUAL, "org.jvnet.hk2.generator.tests.StreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_NAME, "getStreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.PARENT_CONFIGURED, AddressBean.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From the @CreateMe on getSecondaryStreetAddress on AddressBean
             DescriptorImpl envItself = new DescriptorImpl();
@@ -309,10 +309,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_ACTUAL, "org.jvnet.hk2.generator.tests.StreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_NAME, "getSecondaryStreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.PARENT_CONFIGURED, AddressBean.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From the @DeleteMe on getStreetAddress on AddressBean
             DescriptorImpl envItself = new DescriptorImpl();
@@ -322,10 +322,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_ACTUAL, "org.jvnet.hk2.generator.tests.StreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_NAME, "getStreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.PARENT_CONFIGURED, AddressBean.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From the @CreateMe on the DecoratedTown class (using @Decorate)
             DescriptorImpl envItself = new DescriptorImpl();
@@ -337,10 +337,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_ACTUAL, "org.jvnet.hk2.generator.tests.DecoratedTown");
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_NAME, "getTown");
             envItself.addMetadata(GenerateServiceFromMethod.PARENT_CONFIGURED, AddressBean.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From the @CreateMe on the getZipCode method on the DecoratedTown class
             DescriptorImpl envItself = new DescriptorImpl();
@@ -352,10 +352,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_ACTUAL, "org.jvnet.hk2.generator.tests.ZipCode");
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_NAME, "getZipCodes");
             envItself.addMetadata(GenerateServiceFromMethod.PARENT_CONFIGURED, DecoratedTown.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From the @CreateMe on the getZipCode method on the DecoratedTown class
             DescriptorImpl envItself = new DescriptorImpl();
@@ -367,10 +367,10 @@ public class InhabitantsGeneratorTest {
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_ACTUAL, "org.jvnet.hk2.generator.tests.StreetAddress");
             envItself.addMetadata(GenerateServiceFromMethod.METHOD_NAME, "setMyAddress");
             envItself.addMetadata(GenerateServiceFromMethod.PARENT_CONFIGURED, AddressBean.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a service with @UseProxy explicitly set to true
             DescriptorImpl envItself = new DescriptorImpl();
@@ -378,10 +378,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(ServiceWithTrueProxy.class.getName());
             envItself.setScope(Singleton.class.getName());
             envItself.setProxiable(Boolean.TRUE);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a service with @UseProxy explicitly set to false
             DescriptorImpl envItself = new DescriptorImpl();
@@ -389,10 +389,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(ServiceWithFalseProxy.class.getName());
             envItself.setScope(PerLookup.class.getName());
             envItself.setProxiable(Boolean.FALSE);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a service with @UseProxy using default value (should be true)
             DescriptorImpl envItself = new DescriptorImpl();
@@ -400,10 +400,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(ServiceWithDefaultProxy.class.getName());
             envItself.setScope(Singleton.class.getName());
             envItself.setProxiable(Boolean.TRUE);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with default @UseProxy on the provide method.  Service descriptor
             DescriptorImpl envItself = new DescriptorImpl();
@@ -411,10 +411,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(FactoryWithDefaultProxy.class.getName());
             envItself.addAdvertisedContract(Factory.class.getName());
             envItself.setScope(Singleton.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with default @UseProxy on the provide method.  Method descriptor
             DescriptorImpl envItself = new DescriptorImpl();
@@ -423,10 +423,10 @@ public class InhabitantsGeneratorTest {
             envItself.setScope(Singleton.class.getName());
             envItself.setProxiable(Boolean.TRUE);
             envItself.setDescriptorType(DescriptorType.PROVIDE_METHOD);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with false @UseProxy on the provide method.  Service descriptor
             DescriptorImpl envItself = new DescriptorImpl();
@@ -434,10 +434,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(FactoryWithFalseProxy.class.getName());
             envItself.addAdvertisedContract(Factory.class.getName());
             envItself.setScope(Singleton.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with false @UseProxy on the provide method.  Method descriptor
             DescriptorImpl envItself = new DescriptorImpl();
@@ -446,10 +446,10 @@ public class InhabitantsGeneratorTest {
             envItself.setScope(Singleton.class.getName());
             envItself.setProxiable(Boolean.FALSE);
             envItself.setDescriptorType(DescriptorType.PROVIDE_METHOD);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a service with LOCAL visibility
             DescriptorImpl envItself = new DescriptorImpl();
@@ -457,20 +457,20 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(LocalService.class.getName());
             envItself.setScope(Singleton.class.getName());
             envItself.setDescriptorVisibility(DescriptorVisibility.LOCAL);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a service with NORMAL visiblity
             DescriptorImpl envItself = new DescriptorImpl();
             envItself.setImplementation(NormalService.class.getName());
             envItself.addAdvertisedContract(NormalService.class.getName());
             envItself.setScope(Singleton.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with LOCAL visiblity (service descriptor)
             DescriptorImpl envItself = new DescriptorImpl();
@@ -478,10 +478,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(FactoryWithVisibility.class.getName());
             envItself.addAdvertisedContract(Factory.class.getName());
             envItself.setDescriptorVisibility(DescriptorVisibility.LOCAL);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with LOCAL visibility (method descriptor)
             DescriptorImpl envItself = new DescriptorImpl();
@@ -489,10 +489,10 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(String.class.getName());
             envItself.setDescriptorVisibility(DescriptorVisibility.LOCAL);
             envItself.setDescriptorType(DescriptorType.PROVIDE_METHOD);
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
-        
+
         {
             // From a factory with LOCAL visibility (method descriptor)
             DescriptorImpl envItself = new DescriptorImpl();
@@ -500,21 +500,21 @@ public class InhabitantsGeneratorTest {
             envItself.addAdvertisedContract(CustomAnalysisService.class.getName());
             envItself.setClassAnalysisName(CUSTOM_ANALYZER);
             envItself.setScope(Singleton.class.getName());
-            
+
             EXPECTED_DESCRIPTORS.put(envItself, 0);
         }
     }
-    
+
     private File gendirDirectory;
     private File negativeDirectory;
     private File gendirJar;
     private File gendirCopyJar;
     private File inhabitantsDirectory;
-    
+
     private static void copyFile(File to, File from) throws IOException {
         FileInputStream fis = new FileInputStream(from);
         FileOutputStream fos = new FileOutputStream(to);
-        
+
         byte buffer[] = new byte[2000];
         int read;
         while ((read = fis.read(buffer)) >= 0) {
@@ -522,21 +522,21 @@ public class InhabitantsGeneratorTest {
                 fos.write(buffer, 0, read);
             }
         }
-        
+
         fos.close();
         fis.close();
     }
-    
+
     /**
      * Setup before every test
      */
     @Before
     public void before() {
         String buildDir = System.getProperty("build.dir");
-        
+
         if (buildDir != null) {
             File buildDirFile = new File(buildDir);
-            
+
             File mavenClassesDir = new File(buildDirFile, MAVEN_CLASSES_DIR);
             gendirDirectory = new File(mavenClassesDir, CLASS_DIRECTORY);
             negativeDirectory = new File(mavenClassesDir, NEGATIVE_CLASS_DIRECTORY);
@@ -549,78 +549,78 @@ public class InhabitantsGeneratorTest {
             gendirJar = new File(JAR_FILE);
             gendirCopyJar = new File(COPIED_INPUT_JAR_NAME);
         }
-        
+
         File metaInfFile = new File(gendirDirectory, META_INF_NAME);
         inhabitantsDirectory = new File(metaInfFile, INHABITANTS);
     }
-    
+
     private Set<DescriptorImpl> getAllDescriptorsFromInputStream(InputStream is) throws IOException {
         BufferedReader pr = new BufferedReader(new InputStreamReader(is));
-        
+
         Set<DescriptorImpl> retVal = new HashSet<DescriptorImpl>();
         while (pr.ready()) {
             DescriptorImpl di = new DescriptorImpl();
-            
+
             if (!di.readObject(pr)) {
                 continue;
             }
-            
+
             retVal.add(di);
         }
-        
+
         return retVal;
     }
-    
+
     private void checkDescriptors(Set<DescriptorImpl> dis) {
         for (DescriptorImpl di : dis) {
             Assert.assertTrue("Did not find " + di + " in the expected descriptors <<<" +
               EXPECTED_DESCRIPTORS + ">>>", EXPECTED_DESCRIPTORS.containsKey(di));
-            
+
             // The rank is not part of the calculated equals or hash code (since it can change
             // over the course of the lifeycle of the object) and hence must be checked
             // separately from the containsKey above
             int expectedRank = EXPECTED_DESCRIPTORS.get(di);
             Assert.assertEquals(expectedRank, di.getRanking());
         }
-        
+
         for (DescriptorImpl expected : EXPECTED_DESCRIPTORS.keySet()) {
-            Assert.assertTrue("Did not find " + expected + "in the produced descriptors <<<" + 
+            Assert.assertTrue("Did not find " + expected + "in the produced descriptors <<<" +
                     dis + ">>>", dis.contains(expected));
-            
+
         }
-        
+
         Assert.assertEquals("Expecting " + EXPECTED_DESCRIPTORS.size() + " descriptors, but only got " + dis.size(),
                 EXPECTED_DESCRIPTORS.size(), dis.size());
     }
-    
+
     /**
      * Tests generating into a directory
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     @Test
     public void testDefaultDirectoryGeneration() throws IOException {
         String argv[] = new String[2];
-        
+
         argv[0] = FILE_ARGUMENT;
         argv[1] = gendirDirectory.getAbsolutePath();
-        
+
         File defaultOutput = new File(inhabitantsDirectory, DEFAULT);
         if (defaultOutput.exists()) {
             // Start with a clean plate
             Assert.assertTrue(defaultOutput.delete());
         }
-        
+
         try {
             int result = HabitatGenerator.embeddedMain(argv);
             Assert.assertEquals("Got error code: " + result, 0, result);
-            
+
             Assert.assertTrue("did not generate " + defaultOutput.getAbsolutePath(),
                     defaultOutput.exists());
-            
+
             Set<DescriptorImpl> generatedImpls = getAllDescriptorsFromInputStream(
                     new FileInputStream(defaultOutput));
-            
+
             checkDescriptors(generatedImpls);
         }
         finally {
@@ -628,39 +628,39 @@ public class InhabitantsGeneratorTest {
             defaultOutput.delete();
         }
     }
-    
+
     /**
      * Tests generating into a directory
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     @Test
     public void testNonDefaultDirectoryGeneration() throws IOException {
         String argv[] = new String[6];
-        
+
         argv[0] = FILE_ARGUMENT;
         argv[1] = gendirDirectory.getAbsolutePath();
         argv[2] = VERBOSE_ARGUMENT;
         argv[3] = NOSWAP_ARGUMENT;
         argv[4] = LOCATOR_ARGUMENT;
         argv[5] = OTHER;
-        
+
         File defaultOutput = new File(inhabitantsDirectory, OTHER);
         if (defaultOutput.exists()) {
             // Start with a clean plate
             Assert.assertTrue(defaultOutput.delete());
         }
-        
+
         try {
             int result = HabitatGenerator.embeddedMain(argv);
             Assert.assertEquals("Got error code: " + result, 0, result);
-            
+
             Assert.assertTrue("did not generate " + defaultOutput.getAbsolutePath(),
                     defaultOutput.exists());
-            
+
             Set<DescriptorImpl> generatedImpls = getAllDescriptorsFromInputStream(
                     new FileInputStream(defaultOutput));
-            
+
             checkDescriptors(generatedImpls);
         }
         finally {
@@ -668,7 +668,7 @@ public class InhabitantsGeneratorTest {
             defaultOutput.delete();
         }
     }
-    
+
     /**
      * Tests generating into a jar file
      * @throws IOException On failure
@@ -676,53 +676,53 @@ public class InhabitantsGeneratorTest {
     @Test
     public void testDefaultJarGeneration() throws IOException {
         String argv[] = new String[4];
-        
+
         argv[0] = FILE_ARGUMENT;
         argv[1] = gendirJar.getAbsolutePath();
-        
+
         argv[2] = OUTJAR_FILE_ARGUMENT;
         argv[3] = OUTJAR_FILE.getAbsolutePath();
-        
+
         Assert.assertTrue("Could not find file " + gendirJar.getAbsolutePath(),
                 gendirJar.exists());
-        
+
         if (OUTJAR_FILE.exists()) {
             // Start with a clean plate
             Assert.assertTrue(OUTJAR_FILE.delete());
         }
-        
+
         JarFile jar = null;
         try {
             int result = HabitatGenerator.embeddedMain(argv);
             Assert.assertEquals("Got error code: " + result, 0, result);
-            
+
             Assert.assertTrue("did not generate JAR " + OUTJAR_FILE.getAbsolutePath(),
                     OUTJAR_FILE.exists());
-            
+
             jar = new JarFile(OUTJAR_FILE);
             ZipEntry entry = jar.getEntry(ZIP_FILE_INHABITANT_NAME);
             Assert.assertNotNull(entry);
-            
+
             InputStream is = jar.getInputStream(entry);
-            
+
             Set<DescriptorImpl> generatedImpls = getAllDescriptorsFromInputStream(is);
-            
+
             checkDescriptors(generatedImpls);
         }
         finally {
             if (jar != null) {
                 jar.close();
             }
-            
+
             // The test should be clean
             OUTJAR_FILE.delete();
         }
     }
-    
+
     /**
      * Tests generating into a jar file
      * @throws IOException On failure
-     * @throws InterruptedException 
+     * @throws InterruptedException
      */
     @Test
     public void testNoSwapNonDefaultJarGeneration() throws IOException, InterruptedException {
@@ -730,75 +730,75 @@ public class InhabitantsGeneratorTest {
             // Start with a clean plate
             Assert.assertTrue(gendirCopyJar.delete());
         }
-        
+
         copyFile(gendirCopyJar, gendirJar);
-        
+
         String argv[] = new String[5];
-        
+
         argv[0] = FILE_ARGUMENT;
         argv[1] = gendirCopyJar.getAbsolutePath();
-        
+
         argv[2] = NOSWAP_ARGUMENT;
-        
+
         argv[3] = LOCATOR_ARGUMENT;
         argv[4] = NON_DEFAULT_NAME;
-        
+
         Assert.assertTrue("Could not find file " + gendirJar.getAbsolutePath(),
                 gendirJar.exists());
-        
+
         int result = HabitatGenerator.embeddedMain(argv);
         Assert.assertEquals("Got error code: " + result, 0, result);
-            
+
         Assert.assertTrue("did not generate JAR " + gendirCopyJar.getAbsolutePath(),
                 gendirCopyJar.exists());
-            
+
         URI jarURI = URI.create("jar:" + gendirCopyJar.toURI());
-            
+
         InputStream is = null;
         FileSystem fileSystem = FileSystems.newFileSystem(jarURI, new HashMap<String, Object>());
         try {
             Path path = fileSystem.getPath("/" + META_INF_NAME, INHABITANTS, NON_DEFAULT_NAME);
-                
+
             Assert.assertTrue(Files.isReadable(path));
-                
+
             is = Files.newInputStream(path, StandardOpenOption.READ);
-                
+
             Set<DescriptorImpl> generatedImpls = getAllDescriptorsFromInputStream(is);
-                
+
             checkDescriptors(generatedImpls);
-                
+
         }
         finally {
             if (is != null) is.close();
-                
+
             fileSystem.close();
         }
-        
+
     }
-    
+
     /**
      * Tests that a service with two scopes will cause a failure
-     * 
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     *
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     @Test // @org.junit.Ignore
     public void testServiceWithTwoScopes() throws IOException {
         String argv[] = new String[2];
-        
+
         argv[0] = FILE_ARGUMENT;
         argv[1] = negativeDirectory.getAbsolutePath();
-        
+
         File defaultOutput = new File(inhabitantsDirectory, DEFAULT);
         if (defaultOutput.exists()) {
             // Start with a clean plate
             Assert.assertTrue(defaultOutput.delete());
         }
-        
+
         try {
             int result = HabitatGenerator.embeddedMain(argv);
             Assert.assertNotSame("Got error code: " + result, 0, result);
-            
+
             Assert.assertFalse("generated output in negative case " + defaultOutput.getAbsolutePath(),
                     defaultOutput.exists());
         }
@@ -807,51 +807,51 @@ public class InhabitantsGeneratorTest {
             defaultOutput.delete();
         }
     }
-    
+
     private static List<File> convertClasspathToFiles() {
         StringTokenizer tokenizer = new StringTokenizer(CLASSPATH, File.pathSeparator);
-        
+
         LinkedList<File> retVal = new LinkedList<File>();
         while (tokenizer.hasMoreTokens()) {
             String file = tokenizer.nextToken();
-            
+
             retVal.add(new File(file));
         }
-        
+
         return retVal;
     }
-    
+
     /**
      * Tests the in-flight generator
      */
     @Test // @org.junit.Ignore
     public void testInFlightGenerator() throws IOException {
         ServiceLoader<InFlightGenerator> loader = ServiceLoader.load(InFlightGenerator.class);
-        
+
         InFlightGenerator generator = null;
         for (InFlightGenerator candidate : loader) {
             generator = candidate;
             break;
         }
-        
+
         Assert.assertNotNull(generator);
-        
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        
+
         generator.generateFromMultipleDirectories(Collections.singletonList(gendirDirectory),
                 convertClasspathToFiles(),
                 false,
                 baos);
-        
+
         baos.close();
-        
+
         byte[] data = baos.toByteArray();
-        
+
         ByteArrayInputStream bais = new ByteArrayInputStream(data);
         Set<DescriptorImpl> generatedImpls = getAllDescriptorsFromInputStream(bais);
-        
+
         bais.close();
-        
+
         checkDescriptors(generatedImpls);
     }
 }

--- a/maven-plugins/osgiversion-maven-plugin/pom.xml
+++ b/maven-plugins/osgiversion-maven-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2019 Payara Services Ltd.
 
@@ -54,6 +54,15 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-osgi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/osgi/adapter-tests/osgi-adapter-test/pom.xml
+++ b/osgi/adapter-tests/osgi-adapter-test/pom.xml
@@ -138,12 +138,6 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
@@ -192,6 +186,21 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/osgi/adapter/pom.xml
+++ b/osgi/adapter/pom.xml
@@ -76,6 +76,18 @@
             <artifactId>org.apache.felix.bundlerepository</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/AbstractOSGiModulesRegistryImpl.java
+++ b/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/AbstractOSGiModulesRegistryImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 Payara Services Ltd.
  *
@@ -17,25 +18,48 @@
 
 package org.jvnet.hk2.osgiadapter;
 
-import com.sun.enterprise.module.*;
+import com.sun.enterprise.module.HK2Module;
+import com.sun.enterprise.module.ModuleChangeListener;
+import com.sun.enterprise.module.ModuleDefinition;
+import com.sun.enterprise.module.ModuleLifecycleListener;
+import com.sun.enterprise.module.ModulesRegistry;
+import com.sun.enterprise.module.Repository;
+import com.sun.enterprise.module.ResolveError;
 import com.sun.enterprise.module.bootstrap.BootException;
 import com.sun.enterprise.module.common_impl.AbstractModulesRegistryImpl;
 import com.sun.enterprise.module.common_impl.CompositeEnumeration;
-import org.glassfish.hk2.api.*;
-import org.glassfish.hk2.api.Filter;
-import org.glassfish.hk2.utilities.DescriptorImpl;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-import org.osgi.framework.*;
-import org.osgi.service.packageadmin.PackageAdmin;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
+
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.Descriptor;
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.PopulatorPostProcessor;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorState;
+import org.glassfish.hk2.utilities.DescriptorImpl;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.packageadmin.PackageAdmin;
 
 import static org.glassfish.hk2.utilities.ServiceLocatorUtilities.createDynamicConfiguration;
 import static org.jvnet.hk2.osgiadapter.Logger.logger;
@@ -374,7 +398,9 @@ public abstract class AbstractOSGiModulesRegistryImpl extends AbstractModulesReg
         Set<ServiceLocator> locators = getAllServiceLocators();
 
         for (ServiceLocator locator : locators) {
-            if (!ServiceLocatorState.RUNNING.equals(locator.getState())) continue;
+            if (!ServiceLocatorState.RUNNING.equals(locator.getState())) {
+                continue;
+            }
 
             ServiceLocatorUtilities.removeFilter(locator, new RemoveFilter(bsn, version));
         }
@@ -403,10 +429,14 @@ public abstract class AbstractOSGiModulesRegistryImpl extends AbstractModulesReg
         @Override
         public boolean matches(Descriptor d) {
             String dBSN = getMetadataValue(d, OsgiPopulatorPostProcessor.BUNDLE_SYMBOLIC_NAME);
-            if (dBSN == null || !dBSN.equals(bsn)) return false;
+            if (dBSN == null || !dBSN.equals(bsn)) {
+                return false;
+            }
 
             String dVersion = getMetadataValue(d, OsgiPopulatorPostProcessor.BUNDLE_VERSION);
-            if (dVersion == null) return false;
+            if (dVersion == null) {
+                return false;
+            }
 
             return dVersion.equals(version);
         }

--- a/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinter.java
+++ b/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinter.java
@@ -220,7 +220,7 @@ public class FelixPrettyPrinter {
 
     public static String addBundleInfo(Bundle bundle, String prettyMessage) {
         final StringBuilder bundleBuilder = new StringBuilder(1024);
-        bundleBuilder.append("\n").append(prettyMessage);
+        bundleBuilder.append('\n').append(prettyMessage);
         if (bundle != null) {
             bundleBuilder.append('[').append(bundle.getBundleId()).append("] \n");
             bundleBuilder.append("jar = ").append(bundle.getLocation());
@@ -254,11 +254,11 @@ public class FelixPrettyPrinter {
                                  .append(" [")
                                  .append(bundle.getBundleId())
                                  .append("]")
-                                 .append("\n")
+                                 .append('\n')
                                  ;
                 }
             }
-            bundleBuilder.append("\n");
+            bundleBuilder.append('\n');
         }
 
         return bundleIDs;
@@ -329,6 +329,6 @@ public class FelixPrettyPrinter {
         for (int i = 0; i < (indent * 4); i++) {
             messageBuilder.append(" ");
         }
-        messageBuilder.append(message.trim()).append("\n");
+        messageBuilder.append(message.trim()).append('\n');
     }
 }

--- a/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinter.java
+++ b/osgi/adapter/src/main/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinter.java
@@ -48,10 +48,6 @@ public class FelixPrettyPrinter {
 
     private static final Pattern BUNDLE_PATTERN = Pattern.compile("\\[(\\d+)\\]", Pattern.MULTILINE);
 
-    public static void main(String[] args) {
-        System.out.println(prettyPrintExceptionMessage("org.osgi.framework.BundleException: Unable to resolve org.glassfish.main.web.weld-integration [41](R 41.0): missing requirement [org.glassfish.main.web.weld-integration [41](R 41.0)] osgi.wiring.package; (&(osgi.wiring.package=jakarta.faces.application)(version>=4.1.0)(!(version>=5.0.0))) [caused by: Unable to resolve org.glassfish.jakarta.faces [291](R 291.0): missing requirement [org.glassfish.jakarta.faces [291](R 291.0)] osgi.wiring.package; (&(osgi.wiring.package=jakarta.enterprise.inject)(version>=4.1.0)(!(version>=5.0.0)))] Unresolved requirements: [[org.glassfish.main.web.weld-integration [41](R 41.0)] osgi.wiring.package; (&(osgi.wiring.package=jakarta.faces.application)(version>=4.1.0)(!(version>=5.0.0)))]"));
-    }
-
     public static String prettyPrintFelixMessage(BundleContext context, final String bundleMessage) {
         final String prettyMessage = prettyPrintExceptionMessage(bundleMessage);
 

--- a/osgi/adapter/src/test/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinterTest.java
+++ b/osgi/adapter/src/test/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinterTest.java
@@ -16,16 +16,48 @@
 
 package org.jvnet.hk2.osgiadapter;
 
+import java.util.List;
+
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.jvnet.hk2.osgiadapter.FelixPrettyPrinter.prettyPrintExceptionMessage;
 
 public class FelixPrettyPrinterTest {
 
     @Test
-    public void test() {
+    public void testFormatting() {
+        String src = "org.osgi.framework.BundleException:"
+            + " Unable to resolve org.glassfish.main.webservices.connector [207](R 207.0):"
+            + " missing requirement [org.glassfish.main.webservices.connector [207](R 207.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=jakarta.xml.ws)(version>=3.0.0)(!(version>=4.0.0))) [caused by:"
+            + " Unable to resolve org.glassfish.metro.webservices-api-osgi [236](R 236.0):"
+            + " missing requirement [org.glassfish.metro.webservices-api-osgi [236](R 236.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=jakarta.xml.bind)(version>=3.0.0)(!(version>=4.0.0)))]"
+            + " Unresolved requirements: [[org.glassfish.main.webservices.connector [207](R 207.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=jakarta.xml.ws)(version>=3.0.0)(!(version>=4.0.0)))]";
+        String message = FelixPrettyPrinter.prettyPrintExceptionMessage(src);
+        assertThat(message,
+            equalTo(
+                "Unable to resolve\n"
+                    + "    org.glassfish.main.webservices.connector [207]\n"
+                    + "    missing requirement\n"
+                    + "        &(package = jakarta.xml.ws) (version >= 3.0.0) (!(version >= 4.0.0))\n"
+                    + "        caused by:\n"
+                    + "            Unable to resolve\n"
+                    + "                org.glassfish.metro.webservices-api-osgi [236]\n"
+                    + "                missing requirement\n"
+                    + "                    &(package = jakarta.xml.bind) (version >= 3.0.0) (!(version >= 4.0.0)))]\n"));
+
+        assertThat(FelixPrettyPrinter.findBundleIds(message), contains(207L, 236L));
+        assertThat(FelixPrettyPrinter.findBundleIds(src), contains(207L, 236L));
+    }
+
+    @Test
+    public void testWeld() {
         String text = prettyPrintExceptionMessage(
             "org.osgi.framework.BundleException:"
             + " Unable to resolve org.glassfish.main.web.weld-integration [41](R 41.0):"
@@ -41,6 +73,23 @@ public class FelixPrettyPrinterTest {
             stringContainsInOrder("Unable to resolve", "org.glassfish.main.web.weld-integration", "missing requirement",
                 "jakarta.faces.application", "caused by:", "Unable to resolve", "org.glassfish.jakarta.faces",
                 "missing requirement", "jakarta.enterprise.inject", "(version >= 4.1.0) (!(version >= 5.0.0))"));
+        assertThat(FelixPrettyPrinter.findBundleIds(text), contains(41L, 291L));
     }
 
+    @Test
+    public void testFelix() {
+        String src = FelixPrettyPrinter.prettyPrintExceptionMessage("  Unable to resolve"
+            + " org.apache.felix.scr [304](R 304.0):"
+            + " missing requirement [org.apache.felix.scr [304](R 304.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=org.osgi.framework)(version>=1.10.0)(!(version>=2.0.0)))"
+            + " Unresolved requirements: [[org.apache.felix.scr [304](R304.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=org.osgi.framework)(version>=1.10.0)(!(version>=2.0.0)))]\n"
+            + "at org.apache.felix.framework.Felix.resolveBundleRevision(Felix.java:4398) ");
+        String message = FelixPrettyPrinter.prettyPrintExceptionMessage(src);
+        assertThat(message,
+            stringContainsInOrder("Unable to resolve\n", "org.apache.felix.scr [304]\n", "missing requirement\n"));
+
+        List<Long> ids = FelixPrettyPrinter.findBundleIds(message);
+        assertThat(ids, contains(304L));
+    }
 }

--- a/osgi/adapter/src/test/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinterTest.java
+++ b/osgi/adapter/src/test/java/org/jvnet/hk2/osgiadapter/FelixPrettyPrinterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.jvnet.hk2.osgiadapter;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.jvnet.hk2.osgiadapter.FelixPrettyPrinter.prettyPrintExceptionMessage;
+
+public class FelixPrettyPrinterTest {
+
+    @Test
+    public void test() {
+        String text = prettyPrintExceptionMessage(
+            "org.osgi.framework.BundleException:"
+            + " Unable to resolve org.glassfish.main.web.weld-integration [41](R 41.0):"
+            + " missing requirement [org.glassfish.main.web.weld-integration [41](R 41.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=jakarta.faces.application)(version>=4.1.0)(!(version>=5.0.0)))"
+            + " [caused by: Unable to resolve org.glassfish.jakarta.faces [291](R 291.0):"
+            + " missing requirement [org.glassfish.jakarta.faces [291](R 291.0)] osgi.wiring.package;"
+            + " (&(osgi.wiring.package=jakarta.enterprise.inject)(version>=4.1.0)(!(version>=5.0.0)))]"
+            + " Unresolved requirements: [[org.glassfish.main.web.weld-integration [41](R 41.0)]"
+            + " osgi.wiring.package;"
+            + " (&(osgi.wiring.package=jakarta.faces.application)(version>=4.1.0)(!(version>=5.0.0)))]");
+        assertThat(text,
+            stringContainsInOrder("Unable to resolve", "org.glassfish.main.web.weld-integration", "missing requirement",
+                "jakarta.faces.application", "caused by:", "Unable to resolve", "org.glassfish.jakarta.faces",
+                "missing requirement", "jakarta.enterprise.inject", "(version >= 4.1.0) (!(version >= 5.0.0))"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <org.jboss.logging.version>3.6.3.Final</org.jboss.logging.version>
         <jersey.version>4.0.2</jersey.version>
         <grizzly.version>4.0.2</grizzly.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>3.0</hamcrest.version>
         <classmate.version>1.7.3</classmate.version>
         <springcontext.version>6.2.17</springcontext.version>
         <guice.version>7.0.0</guice.version>
@@ -479,16 +479,6 @@
                 <version>${aopalliance.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.easymock</groupId>
-                <artifactId>easymock</artifactId>
-                <version>5.6.0</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
                 <version>${jakarta.validation.version}</version>
@@ -539,11 +529,6 @@
                 <version>${grizzly.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>${hamcrest.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${jakarta.servlet.version}</version>
@@ -558,20 +543,34 @@
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.easymock</groupId>
+                <artifactId>easymock</artifactId>
+                <version>5.6.0</version>
+                <scope>test</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
         <release.arguments />
 
         <manifest.location>target/classes/META-INF/MANIFEST.MF</manifest.location>
+        <activate.securitymanager></activate.securitymanager>
     </properties>
 
     <dependencyManagement>

--- a/spring-bridge/pom.xml
+++ b/spring-bridge/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>spring-bridge</artifactId>
 
     <name>HK2 Spring Bridge</name>
@@ -58,6 +57,14 @@
             <artifactId>hk2-junitrunner</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* Fixes #1277 
* Upgrades hamcrest to 3.0
* Moves implicit dependencies just to poms where they are used