### PR TITLE
Separated project's data pom and parent pom for the build

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -19,13 +19,16 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.glassfish.hk2</groupId>
-        <artifactId>hk2-parent</artifactId>
+        <artifactId>hk2-project</artifactId>
         <version>4.0.1-SNAPSHOT</version>
+        <relativePath>../project</relativePath>
     </parent>
 
     <artifactId>hk2-bom</artifactId>
@@ -178,20 +181,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.glassfish.copyright</groupId>
-                    <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>2.4</version>
-                    <configuration>
-                        <scm>git</scm>
-                        <scmOnly>true</scmOnly>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,101 +19,24 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>2.0.2</version>
-        <relativePath />
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-project</artifactId>
+        <version>4.0.1-SNAPSHOT</version>
+        <relativePath>./project</relativePath>
     </parent>
 
-    <groupId>org.glassfish.hk2</groupId>
     <artifactId>hk2-parent</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GlassFish HK2</name>
     <description>Dependency Injection Kernel</description>
 
-    <url>https://github.com/eclipse-ee4j/glassfish-hk2</url>
-    <inceptionYear>2009</inceptionYear>
-    <licenses>
-        <license>
-            <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>GPL2 w/ CPE</name>
-            <url>https://www.gnu.org/software/classpath/license.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <mailingLists>
-        <mailingList>
-            <name>GlassFish HK2 mailing list</name>
-            <post>glassfish-hk2-dev@eclipse.org</post>
-            <subscribe>https://dev.eclipse.org/mailman/listinfo/glassfish-hk2-dev</subscribe>
-            <unsubscribe>https://dev.eclipse.org/mailman/listinfo/glassfish-hk2-dev</unsubscribe>
-            <archive>https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/</archive>
-        </mailingList>
-    </mailingLists>
-
-    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
-        <connection>scm:git:https://github.com/eclipse-ee4j/glassfish-hk2.git</connection>
-        <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-hk2.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/glassfish-hk2</url>
-        <tag>HEAD</tag>
-    </scm>
-    <issueManagement>
-        <system>Github</system>
-        <url>https://github.com/eclipse-ee4j/glassfish-hk2/issues</url>
-    </issueManagement>
-
-    <developers>
-        <developer>
-            <id>jwells</id>
-            <name>John Wells</name>
-            <organization>Oracle, Inc</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <id>mtaube</id>
-            <name>Mason Taube</name>
-            <organization>Oracle, Inc</organization>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
-    <contributors>
-        <contributor>
-            <name>Jerome Dochez</name>
-            <url>http://blogs.sun.com/dochez</url>
-        </contributor>
-        <contributor>
-            <name>Kohsuke Kawaguchi</name>
-            <url>http://weblogs.java.net/blog/kohsuke</url>
-        </contributor>
-        <contributor>
-            <name>Sanjeeb Sahoo</name>
-            <url>http://weblogs.java.net/ss141213</url>
-        </contributor>
-        <contributor>
-            <name>Andriy Zhdanov</name>
-            <url>http://avalez.blogspot.com</url>
-        </contributor>
-        <contributor>
-            <name>Jeff Trent</name>
-        </contributor>
-    </contributors>
-
     <modules>
+        <module>project</module>
         <module>bom</module>
         <module>maven-plugins</module>
         <module>hk2-metadata-generator</module>
@@ -138,7 +61,6 @@
     <properties>
         <jdk.version>17</jdk.version>
         <mvn.version>3.9.0</mvn.version>
-        <project.build.outputTimestamp>2026-03-24T16:44:27Z</project.build.outputTimestamp>
 
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
@@ -871,15 +793,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>oss-release</id>
-            <properties>
-                <release.projectName>Eclipse HK2</release.projectName>
-                <release.autoPublish>false</release.autoPublish>
-                <release.waitUntil>published</release.waitUntil>
-            </properties>
-        </profile>
-
         <profile>
             <id>securitymanager</id>
             <activation>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2026 Contributors to Eclipse Foundation.
+    Copyright (c) 2020, 2021 Payara Services Ltd.
+    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>2.0.2</version>
+        <relativePath />
+    </parent>
+
+    <groupId>org.glassfish.hk2</groupId>
+    <artifactId>hk2-project</artifactId>
+    <version>4.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>GlassFish HK2 Project POM</name>
+    <description>Dependency Injection Kernel Project POM</description>
+
+    <url>https://github.com/eclipse-ee4j/glassfish-hk2</url>
+    <inceptionYear>2009</inceptionYear>
+    <licenses>
+        <license>
+            <name>EPL 2.0</name>
+            <url>http://www.eclipse.org/legal/epl-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>GPL2 w/ CPE</name>
+            <url>https://www.gnu.org/software/classpath/license.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <mailingLists>
+        <mailingList>
+            <name>GlassFish HK2 mailing list</name>
+            <post>glassfish-hk2-dev@eclipse.org</post>
+            <subscribe>https://dev.eclipse.org/mailman/listinfo/glassfish-hk2-dev</subscribe>
+            <unsubscribe>https://dev.eclipse.org/mailman/listinfo/glassfish-hk2-dev</unsubscribe>
+            <archive>https://dev.eclipse.org/mhonarc/lists/glassfish-hk2-dev/</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+        <connection>scm:git:https://github.com/eclipse-ee4j/glassfish-hk2.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-hk2.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/glassfish-hk2</url>
+        <tag>HEAD</tag>
+    </scm>
+    <issueManagement>
+        <system>Github</system>
+        <url>https://github.com/eclipse-ee4j/glassfish-hk2/issues</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <id>eclipse-glassfish-dev</id>
+            <name>GlassFish Development Team</name>
+            <email>glassfish-dev@eclipse.org</email>
+            <organization>Eclipse Foundation</organization>
+            <organizationUrl>https://www.eclipse.org</organizationUrl>
+            <url>https://projects.eclipse.org/projects/ee4j.glassfish/who</url>
+        </developer>
+    </developers>
+    <contributors>
+        <contributor>
+            <name>GihHub Contributors</name>
+            <url>https://github.com/eclipse-ee4j/glassfish-hk2/graphs/contributors</url>
+        </contributor>
+        <contributor>
+            <name>Jerome Dochez</name>
+            <url>http://blogs.sun.com/dochez</url>
+        </contributor>
+        <contributor>
+            <name>Kohsuke Kawaguchi</name>
+            <url>http://weblogs.java.net/blog/kohsuke</url>
+        </contributor>
+        <contributor>
+            <name>Sanjeeb Sahoo</name>
+            <url>http://weblogs.java.net/ss141213</url>
+        </contributor>
+        <contributor>
+            <name>Andriy Zhdanov</name>
+            <url>http://avalez.blogspot.com</url>
+        </contributor>
+        <contributor>
+            <name>Jeff Trent</name>
+        </contributor>
+        <contributor>
+            <name>John Wells</name>
+            <organization>Oracle, Inc</organization>
+        </contributor>
+        <contributor>
+            <name>Mason Taube</name>
+            <organization>Oracle, Inc</organization>
+        </contributor>
+    </contributors>
+
+    <properties>
+        <project.build.outputTimestamp>2026-03-24T16:44:27Z</project.build.outputTimestamp>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>oss-release</id>
+            <properties>
+                <release.projectName>Eclipse HK2</release.projectName>
+                <release.autoPublish>false</release.autoPublish>
+                <release.waitUntil>published</release.waitUntil>
+            </properties>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
- Fixes the #1291 issue when BOM brought parent's dependency management to the user
- The parent hk2-parent was split to hk2-project
- BOM then needs just the hk2-project
- I also updated the declaration of developers and contributors (using less verbose links to where reader can find the actual information; I kept just the list of contributors from the eras under Sun and Oracle).

### Testing

- GlassFish 8 build with hk2.version=4.0.1-SNAPSHOT
  - `mvn versions:display-dependency-updates -DallowMajorUpdates=false -Pset-version-id -DlogOutput=false` now doesn't report protobuf any more, compared to 4.0.0.
  - `version=4.0.1; mvn release:prepare -DpushChanges=false -DdevelopmentVersion=4.0.2-SNAPSHOT -DreleaseVersion=${version} -Dtag=${version} -Dresume=false -Poss-release` seems to work too, I removed whole hk2 subtree from local maven cache, and checked manually that it updated all required properties in poms.


